### PR TITLE
체스보드와 PawnⓂ️

### DIFF
--- a/ChessGame/ChessGame.xcodeproj/project.pbxproj
+++ b/ChessGame/ChessGame.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		B45686472ADEEC1B002F9EC7 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45686462ADEEC1B002F9EC7 /* File.swift */; };
 		B45686492ADEEC28002F9EC7 /* Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45686482ADEEC28002F9EC7 /* Position.swift */; };
 		B456864B2ADEEC32002F9EC7 /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = B456864A2ADEEC32002F9EC7 /* Pawn.swift */; };
+		B456864E2ADEEC7D002F9EC7 /* ChessBoard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B456864D2ADEEC7D002F9EC7 /* ChessBoard.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +58,7 @@
 		B45686462ADEEC1B002F9EC7 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		B45686482ADEEC28002F9EC7 /* Position.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Position.swift; sourceTree = "<group>"; };
 		B456864A2ADEEC32002F9EC7 /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
+		B456864D2ADEEC7D002F9EC7 /* ChessBoard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessBoard.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,6 +142,7 @@
 			isa = PBXGroup;
 			children = (
 				B456864C2ADEEC3A002F9EC7 /* ChessPiece */,
+				B456864D2ADEEC7D002F9EC7 /* ChessBoard.swift */,
 			);
 			path = ChessTest;
 			sourceTree = "<group>";
@@ -287,6 +290,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B45686472ADEEC1B002F9EC7 /* File.swift in Sources */,
+				B456864E2ADEEC7D002F9EC7 /* ChessBoard.swift in Sources */,
 				B456864B2ADEEC32002F9EC7 /* Pawn.swift in Sources */,
 				B4458F162ADAD6DB00427F6E /* ViewController.swift in Sources */,
 				B45686492ADEEC28002F9EC7 /* Position.swift in Sources */,

--- a/ChessGame/ChessGame.xcodeproj/project.pbxproj
+++ b/ChessGame/ChessGame.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		B4458F292ADAD6DC00427F6E /* ChessGameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F282ADAD6DC00427F6E /* ChessGameTests.swift */; };
 		B4458F332ADAD6DC00427F6E /* ChessGameUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F322ADAD6DC00427F6E /* ChessGameUITests.swift */; };
 		B4458F352ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4458F342ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift */; };
+		B45686452ADEEC12002F9EC7 /* PieceType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45686442ADEEC12002F9EC7 /* PieceType.swift */; };
+		B45686472ADEEC1B002F9EC7 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45686462ADEEC1B002F9EC7 /* File.swift */; };
+		B45686492ADEEC28002F9EC7 /* Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = B45686482ADEEC28002F9EC7 /* Position.swift */; };
+		B456864B2ADEEC32002F9EC7 /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = B456864A2ADEEC32002F9EC7 /* Pawn.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -49,6 +53,10 @@
 		B4458F2E2ADAD6DC00427F6E /* ChessGameUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ChessGameUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4458F322ADAD6DC00427F6E /* ChessGameUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGameUITests.swift; sourceTree = "<group>"; };
 		B4458F342ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGameUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		B45686442ADEEC12002F9EC7 /* PieceType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceType.swift; sourceTree = "<group>"; };
+		B45686462ADEEC1B002F9EC7 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
+		B45686482ADEEC28002F9EC7 /* Position.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Position.swift; sourceTree = "<group>"; };
+		B456864A2ADEEC32002F9EC7 /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,6 +88,7 @@
 			isa = PBXGroup;
 			children = (
 				B4458F102ADAD6DB00427F6E /* ChessGame */,
+				B45686432ADEEBFC002F9EC7 /* ChessTest */,
 				B4458F272ADAD6DC00427F6E /* ChessGameTests */,
 				B4458F312ADAD6DC00427F6E /* ChessGameUITests */,
 				B4458F0F2ADAD6DB00427F6E /* Products */,
@@ -125,6 +134,25 @@
 				B4458F342ADAD6DC00427F6E /* ChessGameUITestsLaunchTests.swift */,
 			);
 			path = ChessGameUITests;
+			sourceTree = "<group>";
+		};
+		B45686432ADEEBFC002F9EC7 /* ChessTest */ = {
+			isa = PBXGroup;
+			children = (
+				B456864C2ADEEC3A002F9EC7 /* ChessPiece */,
+			);
+			path = ChessTest;
+			sourceTree = "<group>";
+		};
+		B456864C2ADEEC3A002F9EC7 /* ChessPiece */ = {
+			isa = PBXGroup;
+			children = (
+				B45686442ADEEC12002F9EC7 /* PieceType.swift */,
+				B45686462ADEEC1B002F9EC7 /* File.swift */,
+				B45686482ADEEC28002F9EC7 /* Position.swift */,
+				B456864A2ADEEC32002F9EC7 /* Pawn.swift */,
+			);
+			path = ChessPiece;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -258,8 +286,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B45686472ADEEC1B002F9EC7 /* File.swift in Sources */,
+				B456864B2ADEEC32002F9EC7 /* Pawn.swift in Sources */,
 				B4458F162ADAD6DB00427F6E /* ViewController.swift in Sources */,
+				B45686492ADEEC28002F9EC7 /* Position.swift in Sources */,
 				B4458F122ADAD6DB00427F6E /* AppDelegate.swift in Sources */,
+				B45686452ADEEC12002F9EC7 /* PieceType.swift in Sources */,
 				B4458F142ADAD6DB00427F6E /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ChessGame/ChessGameTests/ChessGameTests.swift
+++ b/ChessGame/ChessGameTests/ChessGameTests.swift
@@ -25,4 +25,16 @@ final class ChessGameTests: XCTestCase {
     func test_checkInitialPosition() {
         XCTAssertTrue(sut.checkInitialPosition())
     }
+
+    func test_black_movePiece() {
+        let from = Pawn(pieceType: .black, position: Position(rank: 2, file: .D))
+        let to = Pawn(pieceType: .black, position: Position(rank: 3, file: .E))
+        XCTAssertTrue(sut.movePiece(from: from, to: to))
+    }
+
+    func test_white_movePiece() {
+        let from = Pawn(pieceType: .white, position: Position(rank: 7, file: .D))
+        let to = Pawn(pieceType: .white, position: Position(rank: 6, file: .E))
+        XCTAssertTrue(sut.movePiece(from: from, to: to))
+    }
 }

--- a/ChessGame/ChessGameTests/ChessGameTests.swift
+++ b/ChessGame/ChessGameTests/ChessGameTests.swift
@@ -10,27 +10,19 @@ import XCTest
 
 final class ChessGameTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    private var sut: ChessBoard!
+
+    override func setUp() {
+        sut = ChessBoard()
+        super.setUp()
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    func test_checkInitialPosition() {
+        XCTAssertTrue(sut.checkInitialPosition())
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }

--- a/ChessGame/ChessTest/ChessBoard.swift
+++ b/ChessGame/ChessTest/ChessBoard.swift
@@ -1,0 +1,93 @@
+//
+//  ChessBoard.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/18/23.
+//
+
+import Foundation
+
+final class ChessBoard {
+
+    // MARK: - Property
+
+    private var board = Pawn.initPosition()
+
+    // MARK: - Init
+
+    /// 체스 프로그램을 시작하면 흑/백 Pawn을 초기화한다.
+    init() {
+        for file in File.allCases {
+            board[1][file.index] = Pawn(pieceType: .black, position: Position(rank: 1, file: file))
+        }
+        for file in File.allCases {
+            board[6][file.index] = Pawn(pieceType: .white, position: Position(rank: 6, file: file))
+        }
+    }
+
+    // MARK: - Display
+
+    /// 1-rank부터 8-rank까지 rank 문자열로 보드 위에 체스말을 리턴
+    func display() -> String {
+        var boardString = ""
+        var count = 0
+
+        print(" ABCDEFGH")
+        for row in board {
+            count += 1
+            let rowString = row.map { $0.pieceType.rawValue }.joined(separator: "")
+            boardString += "\(count)" + rowString + "\n"
+        }
+        print(boardString)
+        return boardString
+    }
+
+    // MARK: - Initial Position
+
+    /// 입력: 초기화 메서드 테스트 실행
+    func checkInitialPosition() -> Bool {
+        return checkInitialPiecePosition() && checkMaximumPieceCounts()
+    }
+
+    /// 검증1: 체스말 초기 위치가 아니면 생성하지 않는다. (흑색은 2-rank 또는 백색 7-rank)
+    private func checkInitialPiecePosition() -> Bool {
+        for rank in 1...8 {
+            for file in File.allCases {
+                let piece = board[rank - 1][file.index]
+                if (rank == 2 || rank == 7) && (piece.pieceType != .black && piece.pieceType != .white) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    /// 검증2: 체스말 종류별로 최대 개수보다 많이 생성할 수는 없다.
+    /// 검증3: Pawn는 색상별로 8개만 가능하다.
+    private func checkMaximumPieceCounts() -> Bool {
+        var blackPawnsCount = 0
+        var whitePawnsCount = 0
+
+        for rank in 1...8 {
+            for file in File.allCases {
+                let piece = board[rank - 1][file.index]
+
+                if piece.pieceType == .black {
+                    blackPawnsCount += 1
+                } else if piece.pieceType == .white {
+                    whitePawnsCount += 1
+                }
+            }
+        }
+
+        if blackPawnsCount > 8 || whitePawnsCount > 8 {
+            return false
+        }
+
+        if blackPawnsCount != 8 || whitePawnsCount != 8 {
+            return false
+        }
+
+        return true
+    }
+}

--- a/ChessGame/ChessTest/ChessBoard.swift
+++ b/ChessGame/ChessTest/ChessBoard.swift
@@ -90,4 +90,73 @@ final class ChessBoard {
 
         return true
     }
+
+    // MARK: - Move Chess Piece
+
+    /// 입력: 움직이려는 말이 있는 위치(from)와 이동하려는 위치(to)를 차례대로 입력받아서 말을 이동한다.
+    func movePiece(from: Pawn, to: Pawn) -> Bool {
+        return canMove(from: from, to: to) &&
+        isValidRankMove(from: from, to: to) &&
+        isOneSpaceMove(from: from, to: to)
+    }
+
+    private func canMove(from: Pawn, to: Pawn) -> Bool {
+        let pawnAtFromPosition = board[from.position.rank - 1][from.position.file.index]
+        let pawnAtToPosition = board[to.position.rank - 1][to.position.file.index]
+
+        /// 검증1: 형식에 맞지 않으면 다시 입력받는다.
+        guard from.position.isValidPosition() && to.position.isValidPosition() else {
+            return false
+        }
+
+        /// 검증2: from 위치에 동일한 pieceType의 체스말이 존재하는지 확인한다.
+        if pawnAtFromPosition.pieceType != from.pieceType {
+            return false
+        }
+
+        /// 검증3: from과 to의 체스말은 동일할 수 없다.
+        if from.pieceType != to.pieceType {
+            return false
+        }
+
+        /// 검증4: 같은 색상의 말이 to 위치에 다른 말이 이미 있으면 옮길 수 없다.
+        if pawnAtToPosition.pieceType == to.pieceType {
+            return false
+        }
+
+        return true
+    }
+
+    /// 검증5 - 백색은 큰 rank에서 더 작은 rank로 움직일 수 있고, 흑색은 작은 rank에서 더 큰 rank로 움직일 수 있다.
+    private func isValidRankMove(from: Pawn, to: Pawn) -> Bool {
+        let fromPieceRank = from.position.rank
+        let toPieceRank = to.position.rank
+
+        switch from.pieceType {
+        case .black:
+            if fromPieceRank >= toPieceRank {
+                return false
+            }
+        case .white:
+            if fromPieceRank <= toPieceRank {
+                return false
+            }
+        case .dot:
+            return true
+        }
+
+        return true
+    }
+
+    /// 검증6 - 1칸만 움직일 수 있다. (직선/대각선)
+    private func isOneSpaceMove(from: Pawn, to: Pawn) -> Bool {
+        let rankDifference = abs(from.position.rank - to.position.rank)
+        let fileDifference = abs(from.position.file.index - to.position.file.index)
+
+        if rankDifference > 1 || fileDifference > 1 {
+            return false
+        }
+
+        return true
+    }
 }

--- a/ChessGame/ChessTest/ChessBoard.swift
+++ b/ChessGame/ChessTest/ChessBoard.swift
@@ -30,15 +30,10 @@ final class ChessBoard {
     /// 1-rank부터 8-rank까지 rank 문자열로 보드 위에 체스말을 리턴
     func display() -> String {
         var boardString = ""
-        var count = 0
-
-        print(" ABCDEFGH")
         for row in board {
-            count += 1
             let rowString = row.map { $0.pieceType.rawValue }.joined(separator: "")
-            boardString += "\(count)" + rowString + "\n"
+            boardString += rowString + "\n"
         }
-        print(boardString)
         return boardString
     }
 

--- a/ChessGame/ChessTest/ChessPiece/File.swift
+++ b/ChessGame/ChessTest/ChessPiece/File.swift
@@ -1,0 +1,32 @@
+//
+//  File.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/18/23.
+//
+
+import Foundation
+
+enum File: String, CaseIterable {
+    case A
+    case B
+    case C
+    case D
+    case E
+    case F
+    case G
+    case H
+
+    var index: Int {
+        switch self {
+        case .A: 0
+        case .B: 1
+        case .C: 2
+        case .D: 3
+        case .E: 4
+        case .F: 5
+        case .G: 6
+        case .H: 7
+        }
+    }
+}

--- a/ChessGame/ChessTest/ChessPiece/Pawn.swift
+++ b/ChessGame/ChessTest/ChessPiece/Pawn.swift
@@ -1,0 +1,27 @@
+//
+//  Pawn.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/18/23.
+//
+
+import Foundation
+
+struct Pawn {
+    var pieceType: PieceType
+    let position: Position
+
+    static func initPosition() -> [[Pawn]] {
+        var board: [[Pawn]] = []
+
+        for row in 1...8 {
+            var rowPieces: [Pawn] = []
+            for file in File.allCases {
+                rowPieces.append(Pawn(pieceType: .dot, position: Position(rank: row, file: file)))
+            }
+            board.append(rowPieces)
+        }
+
+        return board
+    }
+}

--- a/ChessGame/ChessTest/ChessPiece/PieceType.swift
+++ b/ChessGame/ChessTest/ChessPiece/PieceType.swift
@@ -1,0 +1,14 @@
+//
+//  PieceType.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/18/23.
+//
+
+import Foundation
+
+enum PieceType: String {
+    case black = "♟"
+    case white = "♙"
+    case dot = "."
+}

--- a/ChessGame/ChessTest/ChessPiece/Position.swift
+++ b/ChessGame/ChessTest/ChessPiece/Position.swift
@@ -1,0 +1,19 @@
+//
+//  Position.swift
+//  ChessGame
+//
+//  Created by 강호성 on 10/18/23.
+//
+
+import Foundation
+
+struct Position {
+    let rank: Int   /// row
+    let file: File  /// column
+
+    /// 유효성 검증
+    func isValidPosition() -> Bool {
+        return rank >= 1 && rank <= 8 &&
+        file.index >= 0 && file.index < File.allCases.count
+    }
+}


### PR DESCRIPTION
### 요구사항
- 입출력 뷰와 핵심 로직을 분리해서 설계하고 입출력을 제외한 **핵심 로직만 구현**해야 한다.
- 더 작은 단위나 반복되는 코드가 있다면 일반화해서 별도 클래스로 구현해야 한다.
- 프로그램을 설계할 때 **입력 → 검증 → 처리/계산 → 형식 → 출력** 단계를 구분한다.

### 작업내역
- Board
    - 8x8 크기 체스판에 체스말(Piece) 존재 여부를 관리한다.
        - 가로: rank (row에 해당)
        - 세로: file (column에 해당)
- display()
    - 1-rank부터 8-rank까지 rank 문자열 배열로 보드 위에 체스말을 리턴한다.
- 초기화
    - 초기화 메서드 테스트 실행
       - **검증1**: 체스말 초기 위치가 아니면 생성하지 않는다. (흑색은 2-rank 또는 백색 7-rank)
       - **검증2**: 체스말 종류별로 최대 개수보다 많이 생성할 수는 없다.
       - **검증3**: Pawn는 색상별로 8개만 가능하다.
- canMove
    - **입력** - 움직이려는 말이 있는 위치(from)와 이동하려는 위치(to)를 차례대로 입력받아서 말을 이동한다.
       - **검증1**: 같은 색상의 말이 to 위치에 다른 말이 이미 있으면 옮길 수 없다.
       - **검증2**: from 위치에 동일한 pieceType의 체스말이 존재하는지 확인한다.
       - **검증3**: from과 to의 체스말은 동일할 수 없다.
       - **검증4**: 같은 색상의 말이 to 위치에 다른 말이 이미 있으면 옮길 수 없다.
- movePiece
    - **입력** - 움직이려는 말이 있는 위치(from)와 이동하려는 위치(to)를 차례대로 입력받아서 말을 이동한다.
       - **검증1**: 백색은 큰 rank에서 더 작은 rank로 움직일 수 있고, 흑색은 작은 rank에서 더 큰 rank로 움직일 수 있다.
       - **검증2**: 1칸만 움직일 수 있다. (직선/대각선)

### 학습 진행 내용
- 각 케이스별 유효성 검증을 위한 메서드를 분리하여 작업
- 체스말 움직임의 테스트 과정에서 각 케이스별 테스트 케이스를 만들어서 진행하는지에 대한 고민(궁금증)
   - 현재는 각 type별(black/white)로 움직임에 대한 유효성을 검증하는 테스트 케이스만 존재
- 검증 이후 '처리/계산 → 형식' 단계를 단위 테스트를 통해 어떤 방식으로 테스트하는지에 대한 추가 학습 필요
