### PR TITLE
체스보드와 체스말Ⓜ️

### DIFF
--- a/ChessApp/ChessApp.xcodeproj/project.pbxproj
+++ b/ChessApp/ChessApp.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		CCE167422AE3A18B0065E27F /* Rook.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167412AE3A18B0065E27F /* Rook.swift */; };
 		CCE167442AE3A1C10065E27F /* RookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167432AE3A1C10065E27F /* RookTests.swift */; };
 		CCE167462AE3A6730065E27F /* BoardErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167452AE3A6730065E27F /* BoardErrors.swift */; };
+		CCE167482AE3B7950065E27F /* PieceMovingWay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167472AE3B7950065E27F /* PieceMovingWay.swift */; };
 		CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */; };
 		CCEA52642ADBCE1000CD43ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */; };
 		CCEA52662ADBCE1000CD43ED /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52652ADBCE1000CD43ED /* ViewController.swift */; };
@@ -65,6 +66,7 @@
 		CCE167412AE3A18B0065E27F /* Rook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rook.swift; sourceTree = "<group>"; };
 		CCE167432AE3A1C10065E27F /* RookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookTests.swift; sourceTree = "<group>"; };
 		CCE167452AE3A6730065E27F /* BoardErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardErrors.swift; sourceTree = "<group>"; };
+		CCE167472AE3B7950065E27F /* PieceMovingWay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceMovingWay.swift; sourceTree = "<group>"; };
 		CCEA525E2ADBCE1000CD43ED /* ChessApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 				CC4FCB882ADBD9790084E261 /* Position.swift */,
 				CC4FCB8A2ADBD9E10084E261 /* Color.swift */,
 				CCE167452AE3A6730065E27F /* BoardErrors.swift */,
+				CCE167472AE3B7950065E27F /* PieceMovingWay.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -342,6 +345,7 @@
 			files = (
 				CC4FCB892ADBD9790084E261 /* Position.swift in Sources */,
 				CCEA52662ADBCE1000CD43ED /* ViewController.swift in Sources */,
+				CCE167482AE3B7950065E27F /* PieceMovingWay.swift in Sources */,
 				CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */,
 				CC4FCB7E2ADBD8D90084E261 /* Piece.swift in Sources */,
 				CCE167462AE3A6730065E27F /* BoardErrors.swift in Sources */,

--- a/ChessApp/ChessApp.xcodeproj/project.pbxproj
+++ b/ChessApp/ChessApp.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		CCE167482AE3B7950065E27F /* PieceMovingWay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167472AE3B7950065E27F /* PieceMovingWay.swift */; };
 		CCE1674A2AE3C6AA0065E27F /* Knight.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167492AE3C6AA0065E27F /* Knight.swift */; };
 		CCE1674C2AE3D2190065E27F /* KnightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1674B2AE3D2190065E27F /* KnightTests.swift */; };
+		CCE1674E2AE531340065E27F /* Queen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1674D2AE531340065E27F /* Queen.swift */; };
+		CCE167502AE531E40065E27F /* QueenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1674F2AE531E40065E27F /* QueenTests.swift */; };
 		CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */; };
 		CCEA52642ADBCE1000CD43ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */; };
 		CCEA52662ADBCE1000CD43ED /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52652ADBCE1000CD43ED /* ViewController.swift */; };
@@ -71,6 +73,8 @@
 		CCE167472AE3B7950065E27F /* PieceMovingWay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceMovingWay.swift; sourceTree = "<group>"; };
 		CCE167492AE3C6AA0065E27F /* Knight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Knight.swift; sourceTree = "<group>"; };
 		CCE1674B2AE3D2190065E27F /* KnightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnightTests.swift; sourceTree = "<group>"; };
+		CCE1674D2AE531340065E27F /* Queen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queen.swift; sourceTree = "<group>"; };
+		CCE1674F2AE531E40065E27F /* QueenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueenTests.swift; sourceTree = "<group>"; };
 		CCEA525E2ADBCE1000CD43ED /* ChessApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -131,6 +135,7 @@
 				CCE1673F2AE2AA210065E27F /* Bishop.swift */,
 				CCE167412AE3A18B0065E27F /* Rook.swift */,
 				CCE167492AE3C6AA0065E27F /* Knight.swift */,
+				CCE1674D2AE531340065E27F /* Queen.swift */,
 			);
 			path = Pieces;
 			sourceTree = "<group>";
@@ -152,6 +157,7 @@
 				CCE1673D2AE2A99A0065E27F /* BishopTests.swift */,
 				CCE167432AE3A1C10065E27F /* RookTests.swift */,
 				CCE1674B2AE3D2190065E27F /* KnightTests.swift */,
+				CCE1674F2AE531E40065E27F /* QueenTests.swift */,
 			);
 			path = Pieces;
 			sourceTree = "<group>";
@@ -351,6 +357,7 @@
 			files = (
 				CC4FCB892ADBD9790084E261 /* Position.swift in Sources */,
 				CCEA52662ADBCE1000CD43ED /* ViewController.swift in Sources */,
+				CCE1674E2AE531340065E27F /* Queen.swift in Sources */,
 				CCE167482AE3B7950065E27F /* PieceMovingWay.swift in Sources */,
 				CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */,
 				CC4FCB7E2ADBD8D90084E261 /* Piece.swift in Sources */,
@@ -377,6 +384,7 @@
 				CC4FCB842ADBD9290084E261 /* BoardTests.swift in Sources */,
 				CCE167442AE3A1C10065E27F /* RookTests.swift in Sources */,
 				CCD18EBF2ADBFB33007D02AF /* Position+StringLiteral.swift in Sources */,
+				CCE167502AE531E40065E27F /* QueenTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ChessApp/ChessApp.xcodeproj/project.pbxproj
+++ b/ChessApp/ChessApp.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		CC4FCB8B2ADBD9E10084E261 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4FCB8A2ADBD9E10084E261 /* Color.swift */; };
 		CCD18EBF2ADBFB33007D02AF /* Position+StringLiteral.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD18EBE2ADBFB33007D02AF /* Position+StringLiteral.swift */; };
 		CCD18EC12ADC001B007D02AF /* PostionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD18EC02ADC001B007D02AF /* PostionTests.swift */; };
+		CCE1673E2AE2A99A0065E27F /* BishopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1673D2AE2A99A0065E27F /* BishopTests.swift */; };
+		CCE167402AE2AA210065E27F /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1673F2AE2AA210065E27F /* Bishop.swift */; };
 		CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */; };
 		CCEA52642ADBCE1000CD43ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */; };
 		CCEA52662ADBCE1000CD43ED /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52652ADBCE1000CD43ED /* ViewController.swift */; };
@@ -55,6 +57,8 @@
 		CC4FCB8A2ADBD9E10084E261 /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		CCD18EBE2ADBFB33007D02AF /* Position+StringLiteral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Position+StringLiteral.swift"; sourceTree = "<group>"; };
 		CCD18EC02ADC001B007D02AF /* PostionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostionTests.swift; sourceTree = "<group>"; };
+		CCE1673D2AE2A99A0065E27F /* BishopTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BishopTests.swift; sourceTree = "<group>"; };
+		CCE1673F2AE2AA210065E27F /* Bishop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bishop.swift; sourceTree = "<group>"; };
 		CCEA525E2ADBCE1000CD43ED /* ChessApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -110,6 +114,7 @@
 			children = (
 				CC4FCB7B2ADBD8B30084E261 /* Pawn.swift */,
 				CC4FCB7D2ADBD8D90084E261 /* Piece.swift */,
+				CCE1673F2AE2AA210065E27F /* Bishop.swift */,
 			);
 			path = Pieces;
 			sourceTree = "<group>";
@@ -128,6 +133,7 @@
 			isa = PBXGroup;
 			children = (
 				CC4FCB812ADBD9240084E261 /* PawnTests.swift */,
+				CCE1673D2AE2A99A0065E27F /* BishopTests.swift */,
 			);
 			path = Pieces;
 			sourceTree = "<group>";
@@ -330,6 +336,7 @@
 				CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */,
 				CC4FCB7E2ADBD8D90084E261 /* Piece.swift in Sources */,
 				CC4FCB8B2ADBD9E10084E261 /* Color.swift in Sources */,
+				CCE167402AE2AA210065E27F /* Bishop.swift in Sources */,
 				CC4FCB7A2ADBD8A90084E261 /* Board.swift in Sources */,
 				CC4FCB7C2ADBD8B30084E261 /* Pawn.swift in Sources */,
 				CCEA52642ADBCE1000CD43ED /* SceneDelegate.swift in Sources */,
@@ -340,6 +347,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CCE1673E2AE2A99A0065E27F /* BishopTests.swift in Sources */,
 				CC4FCB822ADBD9240084E261 /* PawnTests.swift in Sources */,
 				CC47D4E82ADEAFD300CE1774 /* Piece+Test.swift in Sources */,
 				CCD18EC12ADC001B007D02AF /* PostionTests.swift in Sources */,

--- a/ChessApp/ChessApp.xcodeproj/project.pbxproj
+++ b/ChessApp/ChessApp.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		CCD18EC12ADC001B007D02AF /* PostionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD18EC02ADC001B007D02AF /* PostionTests.swift */; };
 		CCE1673E2AE2A99A0065E27F /* BishopTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1673D2AE2A99A0065E27F /* BishopTests.swift */; };
 		CCE167402AE2AA210065E27F /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1673F2AE2AA210065E27F /* Bishop.swift */; };
+		CCE167422AE3A18B0065E27F /* Rook.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167412AE3A18B0065E27F /* Rook.swift */; };
+		CCE167442AE3A1C10065E27F /* RookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167432AE3A1C10065E27F /* RookTests.swift */; };
 		CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */; };
 		CCEA52642ADBCE1000CD43ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */; };
 		CCEA52662ADBCE1000CD43ED /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52652ADBCE1000CD43ED /* ViewController.swift */; };
@@ -59,6 +61,8 @@
 		CCD18EC02ADC001B007D02AF /* PostionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostionTests.swift; sourceTree = "<group>"; };
 		CCE1673D2AE2A99A0065E27F /* BishopTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BishopTests.swift; sourceTree = "<group>"; };
 		CCE1673F2AE2AA210065E27F /* Bishop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bishop.swift; sourceTree = "<group>"; };
+		CCE167412AE3A18B0065E27F /* Rook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rook.swift; sourceTree = "<group>"; };
+		CCE167432AE3A1C10065E27F /* RookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookTests.swift; sourceTree = "<group>"; };
 		CCEA525E2ADBCE1000CD43ED /* ChessApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -115,6 +119,7 @@
 				CC4FCB7B2ADBD8B30084E261 /* Pawn.swift */,
 				CC4FCB7D2ADBD8D90084E261 /* Piece.swift */,
 				CCE1673F2AE2AA210065E27F /* Bishop.swift */,
+				CCE167412AE3A18B0065E27F /* Rook.swift */,
 			);
 			path = Pieces;
 			sourceTree = "<group>";
@@ -134,6 +139,7 @@
 			children = (
 				CC4FCB812ADBD9240084E261 /* PawnTests.swift */,
 				CCE1673D2AE2A99A0065E27F /* BishopTests.swift */,
+				CCE167432AE3A1C10065E27F /* RookTests.swift */,
 			);
 			path = Pieces;
 			sourceTree = "<group>";
@@ -335,6 +341,7 @@
 				CCEA52662ADBCE1000CD43ED /* ViewController.swift in Sources */,
 				CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */,
 				CC4FCB7E2ADBD8D90084E261 /* Piece.swift in Sources */,
+				CCE167422AE3A18B0065E27F /* Rook.swift in Sources */,
 				CC4FCB8B2ADBD9E10084E261 /* Color.swift in Sources */,
 				CCE167402AE2AA210065E27F /* Bishop.swift in Sources */,
 				CC4FCB7A2ADBD8A90084E261 /* Board.swift in Sources */,
@@ -352,6 +359,7 @@
 				CC47D4E82ADEAFD300CE1774 /* Piece+Test.swift in Sources */,
 				CCD18EC12ADC001B007D02AF /* PostionTests.swift in Sources */,
 				CC4FCB842ADBD9290084E261 /* BoardTests.swift in Sources */,
+				CCE167442AE3A1C10065E27F /* RookTests.swift in Sources */,
 				CCD18EBF2ADBFB33007D02AF /* Position+StringLiteral.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ChessApp/ChessApp.xcodeproj/project.pbxproj
+++ b/ChessApp/ChessApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		CCE167462AE3A6730065E27F /* BoardErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167452AE3A6730065E27F /* BoardErrors.swift */; };
 		CCE167482AE3B7950065E27F /* PieceMovingWay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167472AE3B7950065E27F /* PieceMovingWay.swift */; };
 		CCE1674A2AE3C6AA0065E27F /* Knight.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167492AE3C6AA0065E27F /* Knight.swift */; };
+		CCE1674C2AE3D2190065E27F /* KnightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1674B2AE3D2190065E27F /* KnightTests.swift */; };
 		CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */; };
 		CCEA52642ADBCE1000CD43ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */; };
 		CCEA52662ADBCE1000CD43ED /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52652ADBCE1000CD43ED /* ViewController.swift */; };
@@ -69,6 +70,7 @@
 		CCE167452AE3A6730065E27F /* BoardErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardErrors.swift; sourceTree = "<group>"; };
 		CCE167472AE3B7950065E27F /* PieceMovingWay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceMovingWay.swift; sourceTree = "<group>"; };
 		CCE167492AE3C6AA0065E27F /* Knight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Knight.swift; sourceTree = "<group>"; };
+		CCE1674B2AE3D2190065E27F /* KnightTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnightTests.swift; sourceTree = "<group>"; };
 		CCEA525E2ADBCE1000CD43ED /* ChessApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				CC4FCB812ADBD9240084E261 /* PawnTests.swift */,
 				CCE1673D2AE2A99A0065E27F /* BishopTests.swift */,
 				CCE167432AE3A1C10065E27F /* RookTests.swift */,
+				CCE1674B2AE3D2190065E27F /* KnightTests.swift */,
 			);
 			path = Pieces;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 				CC4FCB822ADBD9240084E261 /* PawnTests.swift in Sources */,
 				CC47D4E82ADEAFD300CE1774 /* Piece+Test.swift in Sources */,
 				CCD18EC12ADC001B007D02AF /* PostionTests.swift in Sources */,
+				CCE1674C2AE3D2190065E27F /* KnightTests.swift in Sources */,
 				CC4FCB842ADBD9290084E261 /* BoardTests.swift in Sources */,
 				CCE167442AE3A1C10065E27F /* RookTests.swift in Sources */,
 				CCD18EBF2ADBFB33007D02AF /* Position+StringLiteral.swift in Sources */,

--- a/ChessApp/ChessApp.xcodeproj/project.pbxproj
+++ b/ChessApp/ChessApp.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		CCE167402AE2AA210065E27F /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE1673F2AE2AA210065E27F /* Bishop.swift */; };
 		CCE167422AE3A18B0065E27F /* Rook.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167412AE3A18B0065E27F /* Rook.swift */; };
 		CCE167442AE3A1C10065E27F /* RookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167432AE3A1C10065E27F /* RookTests.swift */; };
+		CCE167462AE3A6730065E27F /* BoardErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167452AE3A6730065E27F /* BoardErrors.swift */; };
 		CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */; };
 		CCEA52642ADBCE1000CD43ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */; };
 		CCEA52662ADBCE1000CD43ED /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52652ADBCE1000CD43ED /* ViewController.swift */; };
@@ -63,6 +64,7 @@
 		CCE1673F2AE2AA210065E27F /* Bishop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bishop.swift; sourceTree = "<group>"; };
 		CCE167412AE3A18B0065E27F /* Rook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rook.swift; sourceTree = "<group>"; };
 		CCE167432AE3A1C10065E27F /* RookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookTests.swift; sourceTree = "<group>"; };
+		CCE167452AE3A6730065E27F /* BoardErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardErrors.swift; sourceTree = "<group>"; };
 		CCEA525E2ADBCE1000CD43ED /* ChessApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -109,6 +111,7 @@
 				CC4FCB792ADBD8A90084E261 /* Board.swift */,
 				CC4FCB882ADBD9790084E261 /* Position.swift */,
 				CC4FCB8A2ADBD9E10084E261 /* Color.swift */,
+				CCE167452AE3A6730065E27F /* BoardErrors.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -341,6 +344,7 @@
 				CCEA52662ADBCE1000CD43ED /* ViewController.swift in Sources */,
 				CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */,
 				CC4FCB7E2ADBD8D90084E261 /* Piece.swift in Sources */,
+				CCE167462AE3A6730065E27F /* BoardErrors.swift in Sources */,
 				CCE167422AE3A18B0065E27F /* Rook.swift in Sources */,
 				CC4FCB8B2ADBD9E10084E261 /* Color.swift in Sources */,
 				CCE167402AE2AA210065E27F /* Bishop.swift in Sources */,

--- a/ChessApp/ChessApp.xcodeproj/project.pbxproj
+++ b/ChessApp/ChessApp.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		CCE167442AE3A1C10065E27F /* RookTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167432AE3A1C10065E27F /* RookTests.swift */; };
 		CCE167462AE3A6730065E27F /* BoardErrors.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167452AE3A6730065E27F /* BoardErrors.swift */; };
 		CCE167482AE3B7950065E27F /* PieceMovingWay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167472AE3B7950065E27F /* PieceMovingWay.swift */; };
+		CCE1674A2AE3C6AA0065E27F /* Knight.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCE167492AE3C6AA0065E27F /* Knight.swift */; };
 		CCEA52622ADBCE1000CD43ED /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */; };
 		CCEA52642ADBCE1000CD43ED /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */; };
 		CCEA52662ADBCE1000CD43ED /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCEA52652ADBCE1000CD43ED /* ViewController.swift */; };
@@ -67,6 +68,7 @@
 		CCE167432AE3A1C10065E27F /* RookTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookTests.swift; sourceTree = "<group>"; };
 		CCE167452AE3A6730065E27F /* BoardErrors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardErrors.swift; sourceTree = "<group>"; };
 		CCE167472AE3B7950065E27F /* PieceMovingWay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceMovingWay.swift; sourceTree = "<group>"; };
+		CCE167492AE3C6AA0065E27F /* Knight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Knight.swift; sourceTree = "<group>"; };
 		CCEA525E2ADBCE1000CD43ED /* ChessApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCEA52612ADBCE1000CD43ED /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		CCEA52632ADBCE1000CD43ED /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 				CC4FCB7D2ADBD8D90084E261 /* Piece.swift */,
 				CCE1673F2AE2AA210065E27F /* Bishop.swift */,
 				CCE167412AE3A18B0065E27F /* Rook.swift */,
+				CCE167492AE3C6AA0065E27F /* Knight.swift */,
 			);
 			path = Pieces;
 			sourceTree = "<group>";
@@ -351,6 +354,7 @@
 				CCE167462AE3A6730065E27F /* BoardErrors.swift in Sources */,
 				CCE167422AE3A18B0065E27F /* Rook.swift in Sources */,
 				CC4FCB8B2ADBD9E10084E261 /* Color.swift in Sources */,
+				CCE1674A2AE3C6AA0065E27F /* Knight.swift in Sources */,
 				CCE167402AE2AA210065E27F /* Bishop.swift in Sources */,
 				CC4FCB7A2ADBD8A90084E261 /* Board.swift in Sources */,
 				CC4FCB7C2ADBD8B30084E261 /* Pawn.swift in Sources */,

--- a/ChessApp/ChessApp/Model/Board.swift
+++ b/ChessApp/ChessApp/Model/Board.swift
@@ -10,10 +10,9 @@ import Foundation
 struct Board {
     private(set) var pieces: [Position: Piece] = [:]
     
-    mutating func updatePieces(_ pieces: [Piece]) -> Bool {
+    mutating func updatePieces(_ pieces: [Position: Piece]) -> Bool {
         guard validate(pieces: pieces) else { return false }
-        let piecePairs = pieces.map { ($0.position, $0) }
-        self.pieces = [Position: Piece](uniqueKeysWithValues: piecePairs)
+        self.pieces = pieces
         return true
     }
     
@@ -43,9 +42,9 @@ struct Board {
             .reduce(0, +)
     }
     
-    private func validate(pieces: [Piece]) -> Bool {
+    private func validate(pieces: [Position: Piece]) -> Bool {
         var classified = [String: Int]()
-        for piece in pieces {
+        for piece in pieces.values {
             let identifier = piece.type + "\(piece.color)"
             let count = classified[identifier, default: 0] + 1
             guard piece.maximumCount >= count else {
@@ -58,7 +57,7 @@ struct Board {
     
     private func canMove(from: Position, to: Position) -> Bool {
         guard let fromPiece = pieces[from],
-                fromPiece.availableMovePositions.contains(to) else { return false }
+                fromPiece.availableMovePositions(for: from).contains(to) else { return false }
         guard let toPiece = pieces[to] else { return true }
         return fromPiece.color != toPiece.color
     }

--- a/ChessApp/ChessApp/Model/Board.swift
+++ b/ChessApp/ChessApp/Model/Board.swift
@@ -7,15 +7,6 @@
 
 import Foundation
 
-enum BoardValidateError: Error {
-    case exceedMaximumCount
-}
-
-enum BoardMoveError: Error {
-    case sameColor
-    case invalidDestination
-}
-
 struct Board {
     private(set) var pieces: [Position: Piece] = [:]
     

--- a/ChessApp/ChessApp/Model/Board.swift
+++ b/ChessApp/ChessApp/Model/Board.swift
@@ -53,8 +53,11 @@ struct Board {
     }
     
     private func checkMovable(from: Position, to: Position) throws {
-        guard let fromPiece = pieces[from],
-              fromPiece.availableMovingWays(for: from).contains(where: { $0.canMove(to: to, pieces: pieces) }) == true else { throw BoardMoveError.invalidDestination }
+        guard let fromPiece = pieces[from] else { throw BoardMoveError.invalidStartingPoint }
+        let hasAvailableWay = fromPiece
+            .availableMovingWays(for: from)
+            .contains(where: { $0.canMove(to: to, pieces: pieces) })
+        guard hasAvailableWay else { throw BoardMoveError.invalidDestination }
         guard let toPiece = pieces[to] else { return }
         guard fromPiece.color != toPiece.color else { throw BoardMoveError.sameColor }
     }

--- a/ChessApp/ChessApp/Model/Board.swift
+++ b/ChessApp/ChessApp/Model/Board.swift
@@ -54,7 +54,7 @@ struct Board {
     
     private func checkMovable(from: Position, to: Position) throws {
         guard let fromPiece = pieces[from],
-              fromPiece.availableMovePositions(for: from).contains(to) else { throw BoardMoveError.invalidDestination }
+              fromPiece.availableMovingWays(for: from).contains(where: { $0.canMove(to: to, pieces: pieces) }) == true else { throw BoardMoveError.invalidDestination }
         guard let toPiece = pieces[to] else { return }
         guard fromPiece.color != toPiece.color else { throw BoardMoveError.sameColor }
     }

--- a/ChessApp/ChessApp/Model/Board.swift
+++ b/ChessApp/ChessApp/Model/Board.swift
@@ -36,7 +36,7 @@ struct Board {
     func score(for color: Color) -> Int {
         pieces.values
             .filter { $0.color == color }
-            .map(\.score)
+            .map { type(of: $0).score }
             .reduce(0, +)
     }
     
@@ -45,7 +45,7 @@ struct Board {
         for piece in pieces.values {
             let identifier = piece.type + "\(piece.color)"
             let count = classified[identifier, default: 0] + 1
-            guard piece.maximumCount >= count else {
+            guard type(of: piece).maximumCount >= count else {
                 throw BoardValidateError.exceedMaximumCount
             }
             classified[identifier] = count

--- a/ChessApp/ChessApp/Model/Board.swift
+++ b/ChessApp/ChessApp/Model/Board.swift
@@ -24,10 +24,13 @@ struct Board {
         self.pieces = pieces
     }
     
-    mutating func move(from: Position, to: Position) throws {
+    @discardableResult
+    mutating func move(from: Position, to: Position) throws -> Bool {
         try checkMovable(from: from, to: to)
+        let hasPieceAtDestination = pieces[to] != nil
         pieces[to] = pieces[from]
         pieces[from] = nil
+        return hasPieceAtDestination
     }
     
     func display() -> String {

--- a/ChessApp/ChessApp/Model/Board.swift
+++ b/ChessApp/ChessApp/Model/Board.swift
@@ -7,6 +7,10 @@
 
 import Foundation
 
+enum BoardValidateError: Error {
+    case exceedMaximumCount
+}
+
 enum BoardMoveError: Error {
     case sameColor
     case invalidDestination
@@ -15,10 +19,9 @@ enum BoardMoveError: Error {
 struct Board {
     private(set) var pieces: [Position: Piece] = [:]
     
-    mutating func updatePieces(_ pieces: [Position: Piece]) -> Bool {
-        guard validate(pieces: pieces) else { return false }
+    mutating func updatePieces(_ pieces: [Position: Piece]) throws {
+        try validate(pieces: pieces)
         self.pieces = pieces
-        return true
     }
     
     mutating func move(from: Position, to: Position) throws {
@@ -43,17 +46,16 @@ struct Board {
             .reduce(0, +)
     }
     
-    private func validate(pieces: [Position: Piece]) -> Bool {
+    private func validate(pieces: [Position: Piece]) throws {
         var classified = [String: Int]()
         for piece in pieces.values {
             let identifier = piece.type + "\(piece.color)"
             let count = classified[identifier, default: 0] + 1
             guard piece.maximumCount >= count else {
-                return false
+                throw BoardValidateError.exceedMaximumCount
             }
             classified[identifier] = count
         }
-        return true
     }
     
     private func checkMovable(from: Position, to: Position) throws {

--- a/ChessApp/ChessApp/Model/Board.swift
+++ b/ChessApp/ChessApp/Model/Board.swift
@@ -7,6 +7,11 @@
 
 import Foundation
 
+enum BoardMoveError: Error {
+    case sameColor
+    case invalidDestination
+}
+
 struct Board {
     private(set) var pieces: [Position: Piece] = [:]
     
@@ -16,14 +21,10 @@ struct Board {
         return true
     }
     
-    mutating func move(from: Position, to: Position) -> Bool {
-        guard canMove(from: from, to: to) else {
-            return false
-        }
-        
+    mutating func move(from: Position, to: Position) throws {
+        try checkMovable(from: from, to: to)
         pieces[to] = pieces[from]
         pieces[from] = nil
-        return true
     }
     
     func display() -> String {
@@ -55,10 +56,10 @@ struct Board {
         return true
     }
     
-    private func canMove(from: Position, to: Position) -> Bool {
+    private func checkMovable(from: Position, to: Position) throws {
         guard let fromPiece = pieces[from],
-                fromPiece.availableMovePositions(for: from).contains(to) else { return false }
-        guard let toPiece = pieces[to] else { return true }
-        return fromPiece.color != toPiece.color
+              fromPiece.availableMovePositions(for: from).contains(to) else { throw BoardMoveError.invalidDestination }
+        guard let toPiece = pieces[to] else { return }
+        guard fromPiece.color != toPiece.color else { throw BoardMoveError.sameColor }
     }
 }

--- a/ChessApp/ChessApp/Model/BoardErrors.swift
+++ b/ChessApp/ChessApp/Model/BoardErrors.swift
@@ -14,4 +14,5 @@ enum BoardValidateError: Error {
 enum BoardMoveError: Error {
     case sameColor
     case invalidDestination
+    case invalidStartingPoint
 }

--- a/ChessApp/ChessApp/Model/BoardErrors.swift
+++ b/ChessApp/ChessApp/Model/BoardErrors.swift
@@ -1,0 +1,17 @@
+//
+//  BoardErrors.swift
+//  ChessApp
+//
+//  Created by 현기엽 on 2023/10/21.
+//
+
+import Foundation
+
+enum BoardValidateError: Error {
+    case exceedMaximumCount
+}
+
+enum BoardMoveError: Error {
+    case sameColor
+    case invalidDestination
+}

--- a/ChessApp/ChessApp/Model/PieceMovingWay.swift
+++ b/ChessApp/ChessApp/Model/PieceMovingWay.swift
@@ -1,0 +1,32 @@
+//
+//  PieceMovingWay.swift
+//  ChessApp
+//
+//  Created by 현기엽 on 2023/10/21.
+//
+
+import Foundation
+
+struct PieceMovingWay: Hashable {
+    let rawValue: [Position]
+    
+    func canMove(to destination: Position, pieces: [Position: Piece]) -> Bool {
+        for position in rawValue {
+            if position == destination {
+                return true
+            }
+            if pieces[position] != nil {
+                // 다른 말이 있는경우
+                return false
+            }
+        }
+        // 목적지가 길에 없는 경우
+        return false
+    }
+}
+
+extension PieceMovingWay: ExpressibleByArrayLiteral {
+    init(arrayLiteral elements: Position...) {
+        self.init(rawValue: elements)
+    }
+}

--- a/ChessApp/ChessApp/Model/PieceMovingWay.swift
+++ b/ChessApp/ChessApp/Model/PieceMovingWay.swift
@@ -8,15 +8,23 @@
 import Foundation
 
 struct PieceMovingWay: Hashable {
-    let rawValue: [Position]
+    private let rawValue: [Spot]
+    
+    init(spots: [Spot]) {
+        self.rawValue = spots
+    }
+    
+    init(positions: [Position]) {
+        self.init(spots: positions.map { Spot(position: $0) })
+    }
     
     func canMove(to destination: Position, pieces: [Position: Piece]) -> Bool {
-        for position in rawValue {
-            if position == destination {
-                return true
+        for spot in rawValue {
+            if spot.position == destination {
+                return spot.canStop
             }
-            if pieces[position] != nil {
-                // 다른 말이 있는경우
+            if pieces[spot.position] != nil {
+                // 가는 길에 다른 말이 있는경우
                 return false
             }
         }
@@ -25,8 +33,20 @@ struct PieceMovingWay: Hashable {
     }
 }
 
+extension PieceMovingWay {
+    struct Spot: Hashable {
+        let position: Position
+        let canStop: Bool
+        
+        init(position: Position, canStop: Bool = true) {
+            self.position = position
+            self.canStop = canStop
+        }
+    }
+}
+
 extension PieceMovingWay: ExpressibleByArrayLiteral {
     init(arrayLiteral elements: Position...) {
-        self.init(rawValue: elements)
+        self.init(positions: elements)
     }
 }

--- a/ChessApp/ChessApp/Model/PieceMovingWay.swift
+++ b/ChessApp/ChessApp/Model/PieceMovingWay.swift
@@ -18,6 +18,17 @@ struct PieceMovingWay: Hashable {
         self.init(spots: positions.map { Spot(position: $0) })
     }
     
+    init(for position: Position, fileMultiplier: Int, rankMultiplier: Int, repeat: Int) {
+        guard 1<`repeat` else {
+            self.init(positions: [])
+            return
+        }
+        let positions = (1..<`repeat`).compactMap { (stride: Int) -> Position? in
+            return position.offsetBy(fileOffset: stride * fileMultiplier, rankOffset: stride * rankMultiplier)
+        }
+        self.init(positions: positions)
+    }
+    
     func canMove(to destination: Position, pieces: [Position: Piece]) -> Bool {
         for spot in rawValue {
             if spot.position == destination {

--- a/ChessApp/ChessApp/Model/Pieces/Bishop.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Bishop.swift
@@ -1,0 +1,23 @@
+//
+//  Bishop.swift
+//  ChessApp
+//
+//  Created by 현기엽 on 2023/10/20.
+//
+
+import Foundation
+
+struct Bishop: Piece {
+    let color: Color
+    
+    func availableMovePositions(for position: Position) -> Set<Position> {
+        []
+    }
+    
+    let maximumCount: Int = 2
+    let score: Int = 3
+}
+
+extension Bishop: CustomStringConvertible {
+    var description: String { "" }
+}

--- a/ChessApp/ChessApp/Model/Pieces/Bishop.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Bishop.swift
@@ -19,5 +19,12 @@ struct Bishop: Piece {
 }
 
 extension Bishop: CustomStringConvertible {
-    var description: String { "" }
+    var description: String {
+        switch color {
+        case .black:
+            return "♝"
+        case .white:
+            return "♗"
+        }
+    }
 }

--- a/ChessApp/ChessApp/Model/Pieces/Bishop.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Bishop.swift
@@ -12,25 +12,20 @@ struct Bishop: Piece {
     
     func availableMovingWays(for position: Position) -> Set<PieceMovingWay> {
         [
-            availableMovingWay(for: position, fileTransform: -, rankTransform: -),
-            availableMovingWay(for: position, fileTransform: -, rankTransform: +),
-            availableMovingWay(for: position, fileTransform: +, rankTransform: -),
-            availableMovingWay(for: position, fileTransform: +, rankTransform: +)
+            availableMovingWay(for: position, fileMultiplier: -1, rankMultiplier: -1),
+            availableMovingWay(for: position, fileMultiplier: -1, rankMultiplier: +1),
+            availableMovingWay(for: position, fileMultiplier: +1, rankMultiplier: -1),
+            availableMovingWay(for: position, fileMultiplier: +1, rankMultiplier: +1)
         ]
     }
     
-    private func availableMovingWay(
-        for position: Position,
-        fileTransform: (Int, Int) -> Int,
-        rankTransform: (Int, Int) -> Int) -> PieceMovingWay {
-            let positions = (1..<8).compactMap { (stride: Int) -> Position? in
-                guard let file = Position.File(fileTransform(position.file.rawValue, stride)),
-                      let rank = Position.Rank(rankTransform(position.rank.rawValue, stride)) else {
-                    return nil
-                }
-                return Position(file: file, rank: rank)
-            }
-            return PieceMovingWay(rawValue: positions)
+    private func availableMovingWay(for position: Position,
+                                    fileMultiplier: Int,
+                                    rankMultiplier: Int) -> PieceMovingWay {
+        let positions = (1..<8).compactMap { (stride: Int) -> Position? in
+            return position.offsetBy(fileOffset: stride * fileMultiplier, rankOffset: stride * rankMultiplier)
+        }
+        return PieceMovingWay(rawValue: positions)
     }
     
     let maximumCount: Int = 2

--- a/ChessApp/ChessApp/Model/Pieces/Bishop.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Bishop.swift
@@ -12,20 +12,11 @@ struct Bishop: Piece {
     
     func availableMovingWays(for position: Position) -> Set<PieceMovingWay> {
         [
-            availableMovingWay(for: position, fileMultiplier: -1, rankMultiplier: -1),
-            availableMovingWay(for: position, fileMultiplier: -1, rankMultiplier: +1),
-            availableMovingWay(for: position, fileMultiplier: +1, rankMultiplier: -1),
-            availableMovingWay(for: position, fileMultiplier: +1, rankMultiplier: +1)
+            .init(for: position, fileMultiplier: -1, rankMultiplier: -1, repeat: 8),
+            .init(for: position, fileMultiplier: -1, rankMultiplier: +1, repeat: 8),
+            .init(for: position, fileMultiplier: +1, rankMultiplier: -1, repeat: 8),
+            .init(for: position, fileMultiplier: +1, rankMultiplier: +1, repeat: 8),
         ]
-    }
-    
-    private func availableMovingWay(for position: Position,
-                                    fileMultiplier: Int,
-                                    rankMultiplier: Int) -> PieceMovingWay {
-        let positions = (1..<8).compactMap { (stride: Int) -> Position? in
-            return position.offsetBy(fileOffset: stride * fileMultiplier, rankOffset: stride * rankMultiplier)
-        }
-        return PieceMovingWay(positions: positions)
     }
     
     let maximumCount: Int = 2

--- a/ChessApp/ChessApp/Model/Pieces/Bishop.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Bishop.swift
@@ -25,7 +25,7 @@ struct Bishop: Piece {
         let positions = (1..<8).compactMap { (stride: Int) -> Position? in
             return position.offsetBy(fileOffset: stride * fileMultiplier, rankOffset: stride * rankMultiplier)
         }
-        return PieceMovingWay(rawValue: positions)
+        return PieceMovingWay(positions: positions)
     }
     
     let maximumCount: Int = 2

--- a/ChessApp/ChessApp/Model/Pieces/Bishop.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Bishop.swift
@@ -11,7 +11,25 @@ struct Bishop: Piece {
     let color: Color
     
     func availableMovePositions(for position: Position) -> Set<Position> {
-        []
+        let transformed = (1..<8).flatMap { stride in
+            [
+                Position.Rank(position.rank.rawValue - stride),
+                Position.Rank(position.rank.rawValue + stride)
+            ]
+                .compactMap { $0 }
+                .flatMap { rank in
+                    [
+                        Position.File(position.file.rawValue - stride),
+                        Position.File(position.file.rawValue + stride)
+                    ]
+                        .compactMap { $0 }
+                        .map { file in
+                            Position(file: file, rank: rank)
+                        }
+                }
+        }
+        
+        return Set(transformed)
     }
     
     let maximumCount: Int = 2

--- a/ChessApp/ChessApp/Model/Pieces/Bishop.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Bishop.swift
@@ -10,26 +10,27 @@ import Foundation
 struct Bishop: Piece {
     let color: Color
     
-    func availableMovePositions(for position: Position) -> Set<Position> {
-        let transformed = (1..<8).flatMap { stride in
-            [
-                Position.Rank(position.rank.rawValue - stride),
-                Position.Rank(position.rank.rawValue + stride)
-            ]
-                .compactMap { $0 }
-                .flatMap { rank in
-                    [
-                        Position.File(position.file.rawValue - stride),
-                        Position.File(position.file.rawValue + stride)
-                    ]
-                        .compactMap { $0 }
-                        .map { file in
-                            Position(file: file, rank: rank)
-                        }
+    func availableMovingWays(for position: Position) -> Set<PieceMovingWay> {
+        [
+            availableMovingWay(for: position, fileTransform: -, rankTransform: -),
+            availableMovingWay(for: position, fileTransform: -, rankTransform: +),
+            availableMovingWay(for: position, fileTransform: +, rankTransform: -),
+            availableMovingWay(for: position, fileTransform: +, rankTransform: +)
+        ]
+    }
+    
+    private func availableMovingWay(
+        for position: Position,
+        fileTransform: (Int, Int) -> Int,
+        rankTransform: (Int, Int) -> Int) -> PieceMovingWay {
+            let positions = (1..<8).compactMap { (stride: Int) -> Position? in
+                guard let file = Position.File(fileTransform(position.file.rawValue, stride)),
+                      let rank = Position.Rank(rankTransform(position.rank.rawValue, stride)) else {
+                    return nil
                 }
-        }
-        
-        return Set(transformed)
+                return Position(file: file, rank: rank)
+            }
+            return PieceMovingWay(rawValue: positions)
     }
     
     let maximumCount: Int = 2

--- a/ChessApp/ChessApp/Model/Pieces/Bishop.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Bishop.swift
@@ -19,8 +19,8 @@ struct Bishop: Piece {
         ]
     }
     
-    let maximumCount: Int = 2
-    let score: Int = 3
+    static let maximumCount: Int = 2
+    static let score: Int = 3
 }
 
 extension Bishop: CustomStringConvertible {

--- a/ChessApp/ChessApp/Model/Pieces/Knight.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Knight.swift
@@ -53,8 +53,8 @@ struct Knight: Piece {
             }
     }
     
-    let maximumCount: Int = 2
-    let score: Int = 3
+    static let maximumCount: Int = 2
+    static let score: Int = 3
 }
 
 extension Knight: CustomStringConvertible {

--- a/ChessApp/ChessApp/Model/Pieces/Knight.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Knight.swift
@@ -43,7 +43,7 @@ struct Knight: Piece {
     }
     
     let maximumCount: Int = 2
-    let score: Int = 5
+    let score: Int = 3
 }
 
 extension Knight: CustomStringConvertible {

--- a/ChessApp/ChessApp/Model/Pieces/Knight.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Knight.swift
@@ -1,0 +1,58 @@
+//
+//  Knight.swift
+//  ChessApp
+//
+//  Created by 현기엽 on 2023/10/21.
+//
+
+import Foundation
+
+struct Knight: Piece {
+    let color: Color
+    
+    func availableMovingWays(for position: Position) -> Set<PieceMovingWay> {
+        let ways = [
+            rankTransformed(for: position, multiplier: +1),
+            rankTransformed(for: position, multiplier: -1),
+            fileTransformed(for: position, multiplier: +1),
+            fileTransformed(for: position, multiplier: -1)
+        ].flatMap { $0 }
+        return Set(ways)
+    }
+    
+    private func rankTransformed(for position: Position, multiplier: Int) -> [PieceMovingWay] {
+        guard let forwardPosition = position.offsetBy(fileOffset: 0, rankOffset: multiplier) else {
+            return []
+        }
+        return [
+            forwardPosition.offsetBy(fileOffset: 1, rankOffset: multiplier),
+            forwardPosition.offsetBy(fileOffset: -1, rankOffset: multiplier)
+        ].compactMap { $0 }
+            .map { [forwardPosition, $0] }
+    }
+    
+    private func fileTransformed(for position: Position, multiplier: Int) -> [PieceMovingWay] {
+        guard let forwardPosition = position.offsetBy(fileOffset: multiplier, rankOffset: 0) else {
+            return []
+        }
+        return [
+            forwardPosition.offsetBy(fileOffset: multiplier, rankOffset: 1),
+            forwardPosition.offsetBy(fileOffset: multiplier, rankOffset: -1)
+        ].compactMap { $0 }
+            .map { [forwardPosition, $0] }
+    }
+    
+    let maximumCount: Int = 2
+    let score: Int = 5
+}
+
+extension Knight: CustomStringConvertible {
+    var description: String {
+        switch color {
+        case .black:
+            return "♞"
+        case .white:
+            return "♘"
+        }
+    }
+}

--- a/ChessApp/ChessApp/Model/Pieces/Knight.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Knight.swift
@@ -24,22 +24,33 @@ struct Knight: Piece {
         guard let forwardPosition = position.offsetBy(fileOffset: 0, rankOffset: multiplier) else {
             return []
         }
-        return [
+        let destinations = [
             forwardPosition.offsetBy(fileOffset: 1, rankOffset: multiplier),
             forwardPosition.offsetBy(fileOffset: -1, rankOffset: multiplier)
-        ].compactMap { $0 }
-            .map { [forwardPosition, $0] }
+        ]
+        return pieceMovingWays(destinations: destinations, with: forwardPosition)
     }
     
     private func fileTransformed(for position: Position, multiplier: Int) -> [PieceMovingWay] {
         guard let forwardPosition = position.offsetBy(fileOffset: multiplier, rankOffset: 0) else {
             return []
         }
-        return [
+        let destinations = [
             forwardPosition.offsetBy(fileOffset: multiplier, rankOffset: 1),
             forwardPosition.offsetBy(fileOffset: multiplier, rankOffset: -1)
-        ].compactMap { $0 }
-            .map { [forwardPosition, $0] }
+        ]
+        return pieceMovingWays(destinations: destinations, with: forwardPosition)
+    }
+    
+    private func pieceMovingWays(destinations: [Position?], with forwardPosition: Position) -> [PieceMovingWay] {
+        return destinations
+            .compactMap { $0 }
+            .map { position in
+                PieceMovingWay(spots: [
+                    PieceMovingWay.Spot(position: forwardPosition, canStop: false),
+                    PieceMovingWay.Spot(position: position)
+                ])
+            }
     }
     
     let maximumCount: Int = 2

--- a/ChessApp/ChessApp/Model/Pieces/Pawn.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Pawn.swift
@@ -19,9 +19,8 @@ struct Pawn: Piece {
                 return -1
             }
         }()
-        let expectedRank = Int(position.rank.rawValue) + stride
-        guard expectedRank > 0,
-              let rank = Position.Rank(UInt8(expectedRank)) else { return [] }
+        let expectedRank = position.rank.rawValue + stride
+        guard let rank = Position.Rank(expectedRank) else { return [] }
         return [Position(file: position.file, rank: rank)]
     }
     

--- a/ChessApp/ChessApp/Model/Pieces/Pawn.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Pawn.swift
@@ -9,9 +9,8 @@ import Foundation
 
 struct Pawn: Piece {
     let color: Color
-    var position: Position
     
-    var availableMovePositions: Set<Position> {
+    func availableMovePositions(for position: Position) -> Set<Position> {
         let stride = {
             switch color {
             case .black:

--- a/ChessApp/ChessApp/Model/Pieces/Pawn.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Pawn.swift
@@ -23,8 +23,8 @@ struct Pawn: Piece {
         return [PieceMovingWay(positions: [position])]
     }
     
-    let score: Int = 1
-    let maximumCount: Int = 8
+    static let score: Int = 1
+    static let maximumCount: Int = 8
 }
 
 extension Pawn: CustomStringConvertible {

--- a/ChessApp/ChessApp/Model/Pieces/Pawn.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Pawn.swift
@@ -19,9 +19,8 @@ struct Pawn: Piece {
                 return -1
             }
         }()
-        let expectedRank = position.rank.rawValue + stride
-        guard let rank = Position.Rank(expectedRank) else { return [] }
-        return [PieceMovingWay(rawValue: [Position(file: position.file, rank: rank)])]
+        guard let position = position.offsetBy(fileOffset: 0, rankOffset: stride) else { return [] }
+        return [PieceMovingWay(rawValue: [position])]
     }
     
     let score: Int = 1

--- a/ChessApp/ChessApp/Model/Pieces/Pawn.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Pawn.swift
@@ -10,7 +10,7 @@ import Foundation
 struct Pawn: Piece {
     let color: Color
     
-    func availableMovePositions(for position: Position) -> Set<Position> {
+    func availableMovingWays(for position: Position) -> Set<PieceMovingWay> {
         let stride = {
             switch color {
             case .black:
@@ -21,7 +21,7 @@ struct Pawn: Piece {
         }()
         let expectedRank = position.rank.rawValue + stride
         guard let rank = Position.Rank(expectedRank) else { return [] }
-        return [Position(file: position.file, rank: rank)]
+        return [PieceMovingWay(rawValue: [Position(file: position.file, rank: rank)])]
     }
     
     let score: Int = 1

--- a/ChessApp/ChessApp/Model/Pieces/Pawn.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Pawn.swift
@@ -20,7 +20,7 @@ struct Pawn: Piece {
             }
         }()
         guard let position = position.offsetBy(fileOffset: 0, rankOffset: stride) else { return [] }
-        return [PieceMovingWay(rawValue: [position])]
+        return [PieceMovingWay(positions: [position])]
     }
     
     let score: Int = 1

--- a/ChessApp/ChessApp/Model/Pieces/Piece.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Piece.swift
@@ -9,7 +9,7 @@ import Foundation
 
 protocol Piece: CustomStringConvertible {
     var color: Color { get }
-    func availableMovePositions(for position: Position) -> Set<Position>
+    func availableMovingWays(for position: Position) -> Set<PieceMovingWay>
     
     var maximumCount: Int { get }
     var score: Int { get }

--- a/ChessApp/ChessApp/Model/Pieces/Piece.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Piece.swift
@@ -11,8 +11,8 @@ protocol Piece: CustomStringConvertible {
     var color: Color { get }
     func availableMovingWays(for position: Position) -> Set<PieceMovingWay>
     
-    var maximumCount: Int { get }
-    var score: Int { get }
+    static var maximumCount: Int { get }
+    static var score: Int { get }
 }
 
 extension Piece {

--- a/ChessApp/ChessApp/Model/Pieces/Piece.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Piece.swift
@@ -9,8 +9,7 @@ import Foundation
 
 protocol Piece: CustomStringConvertible {
     var color: Color { get }
-    var position: Position { get set }
-    var availableMovePositions: Set<Position> { get }
+    func availableMovePositions(for position: Position) -> Set<Position>
     
     var maximumCount: Int { get }
     var score: Int { get }

--- a/ChessApp/ChessApp/Model/Pieces/Queen.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Queen.swift
@@ -22,8 +22,9 @@ struct Queen: Piece {
             .init(for: position, fileMultiplier: +1, rankMultiplier: +1, repeat: 8),
         ]
     }
-    let maximumCount: Int = 1
-    let score: Int = 9
+    
+    static let maximumCount: Int = 1
+    static let score: Int = 9
 }
 
 extension Queen: CustomStringConvertible {

--- a/ChessApp/ChessApp/Model/Pieces/Queen.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Queen.swift
@@ -1,0 +1,38 @@
+//
+//  Queen.swift
+//  ChessApp
+//
+//  Created by 현기엽 on 2023/10/22.
+//
+
+import Foundation
+
+struct Queen: Piece {
+    let color: Color
+    
+    func availableMovingWays(for position: Position) -> Set<PieceMovingWay> {
+        return [
+            .init(for: position, fileMultiplier: 0, rankMultiplier: +1, repeat: 8),
+            .init(for: position, fileMultiplier: 0, rankMultiplier: -1, repeat: 8),
+            .init(for: position, fileMultiplier: +1, rankMultiplier:  0, repeat: 8),
+            .init(for: position, fileMultiplier: -1, rankMultiplier:  0, repeat: 8),
+            .init(for: position, fileMultiplier: -1, rankMultiplier: -1, repeat: 8),
+            .init(for: position, fileMultiplier: -1, rankMultiplier: +1, repeat: 8),
+            .init(for: position, fileMultiplier: +1, rankMultiplier: -1, repeat: 8),
+            .init(for: position, fileMultiplier: +1, rankMultiplier: +1, repeat: 8),
+        ]
+    }
+    let maximumCount: Int = 1
+    let score: Int = 9
+}
+
+extension Queen: CustomStringConvertible {
+    var description: String {
+        switch color {
+        case .black:
+            return "♛"
+        case .white:
+            return "♕"
+        }
+    }
+}

--- a/ChessApp/ChessApp/Model/Pieces/Rook.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Rook.swift
@@ -11,27 +11,13 @@ struct Rook: Piece {
     let color: Color
     
     func availableMovingWays(for position: Position) -> Set<PieceMovingWay> {
-        let ways = [
-            rankTransformed(for: position, multiplier: +1),
-            rankTransformed(for: position, multiplier: -1),
-            fileTransformed(for: position, multiplier: +1),
-            fileTransformed(for: position, multiplier: -1)
-        ].map { PieceMovingWay(positions: $0) }
-        return Set(ways)
+        return [
+            .init(for: position, fileMultiplier: 0, rankMultiplier: +1, repeat: 8),
+            .init(for: position, fileMultiplier: 0, rankMultiplier: -1, repeat: 8),
+            .init(for: position, fileMultiplier: +1, rankMultiplier:  0, repeat: 8),
+            .init(for: position, fileMultiplier: -1, rankMultiplier:  0, repeat: 8),
+        ]
     }
-    
-    private func rankTransformed(for position: Position, multiplier: Int) -> [Position] {
-        return (1..<8).compactMap { (rank) -> Position? in
-            position.offsetBy(fileOffset: 0, rankOffset: rank * multiplier)
-        }
-    }
-    
-    private func fileTransformed(for position: Position, multiplier: Int) -> [Position] {
-        return (1..<8).compactMap { (file) -> Position? in
-            position.offsetBy(fileOffset: file * multiplier, rankOffset: 0)
-        }
-    }
-    
     let maximumCount: Int = 2
     let score: Int = 5
 }

--- a/ChessApp/ChessApp/Model/Pieces/Rook.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Rook.swift
@@ -19,5 +19,12 @@ struct Rook: Piece {
 }
 
 extension Rook: CustomStringConvertible {
-    var description: String { "" }
+    var description: String {
+        switch color {
+        case .black:
+            return "♜"
+        case .white:
+            return "♖"
+        }
+    }
 }

--- a/ChessApp/ChessApp/Model/Pieces/Rook.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Rook.swift
@@ -1,0 +1,23 @@
+//
+//  Rook.swift
+//  ChessApp
+//
+//  Created by 현기엽 on 2023/10/21.
+//
+
+import Foundation
+
+struct Rook: Piece {
+    let color: Color
+    
+    func availableMovePositions(for position: Position) -> Set<Position> {
+        []
+    }
+    
+    let maximumCount: Int = 2
+    let score: Int = 5
+}
+
+extension Rook: CustomStringConvertible {
+    var description: String { "" }
+}

--- a/ChessApp/ChessApp/Model/Pieces/Rook.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Rook.swift
@@ -10,28 +10,28 @@ import Foundation
 struct Rook: Piece {
     let color: Color
     
-    func availableMovePositions(for position: Position) -> Set<Position> {
-        let rankTransformed = Position.Rank.range.flatMap { rank in
-            [
-                Position.Rank(position.rank.rawValue - rank),
-                Position.Rank(position.rank.rawValue + rank)
-            ]
-                .compactMap { $0 }
-                .map {
-                    Position(file: position.file, rank: $0)
-                }
+    func availableMovingWays(for position: Position) -> Set<PieceMovingWay> {
+        let ways = [
+            rankTransformed(for: position, transform: +),
+            rankTransformed(for: position, transform: -),
+            fileTransformed(for: position, transform: +),
+            fileTransformed(for: position, transform: -)
+        ].map { PieceMovingWay(rawValue: $0) }
+        return Set(ways)
+    }
+    
+    private func rankTransformed(for position: Position, transform: (Int, Int) -> Int) -> [Position] {
+        return (1..<8).compactMap { (rank) -> Position? in
+            guard let rank = Position.Rank(transform(position.rank.rawValue, rank)) else { return nil }
+            return Position(file: position.file, rank: rank)
         }
-        let fileTransformed = Position.File.range.flatMap { file in
-            [
-                Position.File(position.file.rawValue - file),
-                Position.File(position.file.rawValue + file)
-            ]
-                .compactMap { $0 }
-                .map {
-                    Position(file: $0, rank: position.rank)
-                }
+    }
+    
+    private func fileTransformed(for position: Position, transform: (Int, Int) -> Int) -> [Position] {
+        return (1..<8).compactMap { (file) -> Position? in
+            guard let file = Position.File(transform(position.file.rawValue, file)) else { return nil }
+            return Position(file: file, rank: position.rank)
         }
-        return Set(rankTransformed).union(fileTransformed).subtracting([position])
     }
     
     let maximumCount: Int = 2

--- a/ChessApp/ChessApp/Model/Pieces/Rook.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Rook.swift
@@ -16,7 +16,7 @@ struct Rook: Piece {
             rankTransformed(for: position, multiplier: -1),
             fileTransformed(for: position, multiplier: +1),
             fileTransformed(for: position, multiplier: -1)
-        ].map { PieceMovingWay(rawValue: $0) }
+        ].map { PieceMovingWay(positions: $0) }
         return Set(ways)
     }
     

--- a/ChessApp/ChessApp/Model/Pieces/Rook.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Rook.swift
@@ -11,7 +11,27 @@ struct Rook: Piece {
     let color: Color
     
     func availableMovePositions(for position: Position) -> Set<Position> {
-        []
+        let rankTransformed = Position.Rank.range.flatMap { rank in
+            [
+                Position.Rank(position.rank.rawValue - rank),
+                Position.Rank(position.rank.rawValue + rank)
+            ]
+                .compactMap { $0 }
+                .map {
+                    Position(file: position.file, rank: $0)
+                }
+        }
+        let fileTransformed = Position.File.range.flatMap { file in
+            [
+                Position.File(position.file.rawValue - file),
+                Position.File(position.file.rawValue + file)
+            ]
+                .compactMap { $0 }
+                .map {
+                    Position(file: $0, rank: position.rank)
+                }
+        }
+        return Set(rankTransformed).union(fileTransformed).subtracting([position])
     }
     
     let maximumCount: Int = 2

--- a/ChessApp/ChessApp/Model/Pieces/Rook.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Rook.swift
@@ -12,25 +12,23 @@ struct Rook: Piece {
     
     func availableMovingWays(for position: Position) -> Set<PieceMovingWay> {
         let ways = [
-            rankTransformed(for: position, transform: +),
-            rankTransformed(for: position, transform: -),
-            fileTransformed(for: position, transform: +),
-            fileTransformed(for: position, transform: -)
+            rankTransformed(for: position, multiplier: +1),
+            rankTransformed(for: position, multiplier: -1),
+            fileTransformed(for: position, multiplier: +1),
+            fileTransformed(for: position, multiplier: -1)
         ].map { PieceMovingWay(rawValue: $0) }
         return Set(ways)
     }
     
-    private func rankTransformed(for position: Position, transform: (Int, Int) -> Int) -> [Position] {
+    private func rankTransformed(for position: Position, multiplier: Int) -> [Position] {
         return (1..<8).compactMap { (rank) -> Position? in
-            guard let rank = Position.Rank(transform(position.rank.rawValue, rank)) else { return nil }
-            return Position(file: position.file, rank: rank)
+            position.offsetBy(fileOffset: 0, rankOffset: rank * multiplier)
         }
     }
     
-    private func fileTransformed(for position: Position, transform: (Int, Int) -> Int) -> [Position] {
+    private func fileTransformed(for position: Position, multiplier: Int) -> [Position] {
         return (1..<8).compactMap { (file) -> Position? in
-            guard let file = Position.File(transform(position.file.rawValue, file)) else { return nil }
-            return Position(file: file, rank: position.rank)
+            position.offsetBy(fileOffset: file * multiplier, rankOffset: 0)
         }
     }
     

--- a/ChessApp/ChessApp/Model/Pieces/Rook.swift
+++ b/ChessApp/ChessApp/Model/Pieces/Rook.swift
@@ -18,8 +18,8 @@ struct Rook: Piece {
             .init(for: position, fileMultiplier: -1, rankMultiplier:  0, repeat: 8),
         ]
     }
-    let maximumCount: Int = 2
-    let score: Int = 5
+    static let maximumCount: Int = 2
+    static let score: Int = 5
 }
 
 extension Rook: CustomStringConvertible {

--- a/ChessApp/ChessApp/Model/Position.swift
+++ b/ChessApp/ChessApp/Model/Position.swift
@@ -30,6 +30,10 @@ struct Position: Hashable, CustomStringConvertible {
         var description: String {
             "\(rawValue + 1)"
         }
+        
+        func offsetBy(_ offset: Int) -> Rank? {
+            return Rank(rawValue + offset)
+        }
     }
     
     struct File: Hashable, CustomStringConvertible {
@@ -57,6 +61,10 @@ struct Position: Hashable, CustomStringConvertible {
             }
             return String(unicodeScalar)
         }
+        
+        func offsetBy(_ offset: Int) -> File? {
+            return File(rawValue + offset)
+        }
     }
     
     let file: File
@@ -73,6 +81,12 @@ struct Position: Hashable, CustomStringConvertible {
               let file = File(value[0]),
               let rank = Rank(value[1]) else { return nil }
         self.init(file: file, rank: rank)
+    }
+    
+    func offsetBy(fileOffset: Int, rankOffset: Int) -> Position? {
+        guard let file = file.offsetBy(fileOffset),
+              let rank = rank.offsetBy(rankOffset) else { return nil }
+        return Position(file: file, rank: rank)
     }
     
     var description: String {

--- a/ChessApp/ChessApp/Model/Position.swift
+++ b/ChessApp/ChessApp/Model/Position.swift
@@ -9,10 +9,10 @@ import Foundation
 
 struct Position: Hashable {
     struct Rank: Hashable {
-        static let range: Range<UInt8> = 0..<8
-        private(set) var rawValue: UInt8
+        static let range: Range<Int> = 0..<8
+        private(set) var rawValue: Int
         
-        init?(_ value: UInt8) {
+        init?(_ value: Int) {
             guard Self.range ~= value else { return nil }
             self.rawValue = value
         }
@@ -20,7 +20,7 @@ struct Position: Hashable {
         init?(_ value: Character) {
             guard let value = value.asciiValue,
                   value >= 49 else { return nil }
-            self.init(value - 49) // value - "1"
+            self.init(Int(value) - 49) // value - "1"
         }
         
         static var allCases: [Rank] {
@@ -29,10 +29,10 @@ struct Position: Hashable {
     }
     
     struct File: Hashable {
-        static let range: Range<UInt8> = 0..<8
-        private(set) var rawValue: UInt8
+        static let range: Range<Int> = 0..<8
+        private(set) var rawValue: Int
         
-        init?(_ value: UInt8) {
+        init?(_ value: Int) {
             guard Self.range ~= value else { return nil }
             self.rawValue = value
         }
@@ -40,7 +40,7 @@ struct Position: Hashable {
         init?(_ value: Character) {
             guard let value = value.asciiValue,
                   value >= 65 else { return nil }
-            self.init(value - 65) // value - "A"
+            self.init(Int(value) - 65) // value - "A"
         }
         
         static var allCases: [File] {

--- a/ChessApp/ChessApp/Model/Position.swift
+++ b/ChessApp/ChessApp/Model/Position.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-struct Position: Hashable {
-    struct Rank: Hashable {
+struct Position: Hashable, CustomStringConvertible {
+    struct Rank: Hashable, CustomStringConvertible {
         static let range: Range<Int> = 0..<8
         private(set) var rawValue: Int
         
@@ -26,9 +26,13 @@ struct Position: Hashable {
         static var allCases: [Rank] {
             range.compactMap { Rank($0) }
         }
+        
+        var description: String {
+            "\(rawValue + 1)"
+        }
     }
     
-    struct File: Hashable {
+    struct File: Hashable, CustomStringConvertible {
         static let range: Range<Int> = 0..<8
         private(set) var rawValue: Int
         
@@ -46,6 +50,13 @@ struct Position: Hashable {
         static var allCases: [File] {
             range.compactMap { File($0) }
         }
+        
+        var description: String {
+            guard let unicodeScalar = UnicodeScalar(65 + rawValue) else {
+                return "?"
+            }
+            return String(unicodeScalar)
+        }
     }
     
     let file: File
@@ -62,5 +73,9 @@ struct Position: Hashable {
               let file = File(value[0]),
               let rank = Rank(value[1]) else { return nil }
         self.init(file: file, rank: rank)
+    }
+    
+    var description: String {
+        return file.description + rank.description 
     }
 }

--- a/ChessApp/ChessAppTests/Model/BoardTests.swift
+++ b/ChessApp/ChessAppTests/Model/BoardTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 final class BoardTests: XCTestCase {
     func test초기상태의_점수는_색깔별로_각각_8이다() {
-        let board = Board(pieces: [Piece].initialPieces)
+        let board = Board(pieces: [Position: Piece].initialPieces)
         
         let whiteScore = board.score(for: .white)
         let blackScore = board.score(for: .black)
@@ -20,7 +20,7 @@ final class BoardTests: XCTestCase {
     }
     
     func test빈_Board의_점수는_색깔별로_각각_0이다() {
-        let board = Board(pieces: [])
+        let board = Board(pieces: [:])
         
         let whiteScore = board.score(for: .white)
         let blackScore = board.score(for: .black)
@@ -31,7 +31,7 @@ final class BoardTests: XCTestCase {
     
     func testA6가_빈칸일때_A7에_있는_백색Pawn을_A6으로_옮길_수_있다() {
         var board = Board(pieces: [
-            Pawn(color: .white, position: "A7")
+            "A7": Pawn(color: .white)
         ])
         let result = board.move(from: "A7", to: "A6")
         XCTAssertTrue(result)
@@ -39,10 +39,23 @@ final class BoardTests: XCTestCase {
         XCTAssertNil(board.pieces["A7"])
     }
     
+    func testA7에_있는_백색Pawn을_2턴에_걸쳐_A5으로_옮길_수_있다() {
+        var board = Board(pieces: [
+            "A7": Pawn(color: .white)
+        ])
+        let resultA6 = board.move(from: "A7", to: "A6")
+        let resultA5 = board.move(from: "A6", to: "A5")
+        XCTAssertTrue(resultA6)
+        XCTAssertTrue(resultA5)
+        XCTAssertEqual(board.pieces["A5"]?.color, .white)
+        XCTAssertNil(board.pieces["A6"])
+        XCTAssertNil(board.pieces["A7"])
+    }
+    
     func testA6에_흑색Pawn이_있을때_A7에_있는_백색Pawn을_A6으로_옮길_수_있다() {
         var board = Board(pieces: [
-            Pawn(color: .black, position: "A6"),
-            Pawn(color: .white, position: "A7")
+            "A6": Pawn(color: .black),
+            "A7": Pawn(color: .white)
         ])
         let result = board.move(from: "A7", to: "A6")
         XCTAssertTrue(result)
@@ -52,8 +65,8 @@ final class BoardTests: XCTestCase {
     
     func testA6에_흑색Pawn이_있을때_A7에_있는_백색Pawn을_A6으로_옮겼다가_다시_A7로_옮길_수_없다() {
         var board = Board(pieces: [
-            Pawn(color: .black, position: "A6"),
-            Pawn(color: .white, position: "A7")
+            "A6": Pawn(color: .black),
+            "A7": Pawn(color: .white)
         ])
         _ = board.move(from: "A7", to: "A6")
         let result = board.move(from: "A6", to: "A7")
@@ -64,8 +77,8 @@ final class BoardTests: XCTestCase {
     
     func testA6에_백색Pawn이_있을때_A7에_있는_백색Pawn을_A6으로_옮길_수_없다() {
         var board = Board(pieces: [
-            Pawn(color: .white, position: "A6"),
-            Pawn(color: .white, position: "A7")
+            "A6": Pawn(color: .white),
+            "A7": Pawn(color: .white)
         ])
         let result = board.move(from: "A7", to: "A6")
         XCTAssertFalse(result)
@@ -73,7 +86,7 @@ final class BoardTests: XCTestCase {
     
     func testA7에_있는_백색Pawn을_A5으로_옮길_수_없다() {
         var board = Board(pieces: [
-            Pawn(color: .white, position: "A7")
+            "A7": Pawn(color: .white)
         ])
         let result = board.move(from: "A7", to: "A5")
         XCTAssertFalse(result)
@@ -81,7 +94,7 @@ final class BoardTests: XCTestCase {
     
     func testA7에_있는_백색Pawn을_A8으로_옮길_수_없다() {
         var board = Board(pieces: [
-            Pawn(color: .white, position: "A7")
+            "A7": Pawn(color: .white)
         ])
         let result = board.move(from: "A7", to: "A8")
         XCTAssertFalse(result)
@@ -89,20 +102,20 @@ final class BoardTests: XCTestCase {
     
     func testA7에_있는_흑색Pawn을_A6으로_옮길_수_없다() {
         var board = Board(pieces: [
-            Pawn(color: .black, position: "A7")
+            "A7": Pawn(color: .black)
         ])
         let result = board.move(from: "A7", to: "A6")
         XCTAssertFalse(result)
     }
     
     func testA7에_말이_없을때_A6으로_옮길_수_없다() {
-        var board = Board(pieces: [])
+        var board = Board(pieces: [:])
         let result = board.move(from: "A7", to: "A6")
         XCTAssertFalse(result)
     }
     
     func test초기상태의_board를_display할_수_있다() {
-        let board = Board(pieces: [Piece].initialPieces)
+        let board = Board(pieces: [Position: Piece].initialPieces)
         let expect = """
 ........
 ♟♟♟♟♟♟♟♟
@@ -117,7 +130,7 @@ final class BoardTests: XCTestCase {
     }
     
     func test빈_board를_display할_수_있다() {
-        let board = Board(pieces: [])
+        let board = Board(pieces: [:])
         let expect = """
 ........
 ........
@@ -134,15 +147,15 @@ final class BoardTests: XCTestCase {
     func test흰색_Pawn_9개로_Board를_초기화_할_수_없다() {
         var board = Board()
         let result = board.updatePieces([
-            Pawn(color: .white, position: "A1"),
-            Pawn(color: .white, position: "A4"),
-            Pawn(color: .white, position: "B6"),
-            Pawn(color: .white, position: "A8"),
-            Pawn(color: .white, position: "C2"),
-            Pawn(color: .white, position: "D2"),
-            Pawn(color: .white, position: "E2"),
-            Pawn(color: .white, position: "F4"),
-            Pawn(color: .white, position: "G6")
+            "A1": Pawn(color: .white),
+            "A4": Pawn(color: .white),
+            "B6": Pawn(color: .white),
+            "A8": Pawn(color: .white),
+            "C2": Pawn(color: .white),
+            "D2": Pawn(color: .white),
+            "E2": Pawn(color: .white),
+            "F4": Pawn(color: .white),
+            "G6": Pawn(color: .white)
         ])
         XCTAssertFalse(result)
     }

--- a/ChessApp/ChessAppTests/Model/BoardTests.swift
+++ b/ChessApp/ChessAppTests/Model/BoardTests.swift
@@ -9,8 +9,8 @@ import XCTest
 @testable import ChessApp
 
 final class BoardTests: XCTestCase {
-    func test초기상태의_점수는_색깔별로_각각_8이다() {
-        let board = Board(pieces: [Position: Piece].initialPieces)
+    func test폰이_초기화된_상태의_점수는_색깔별로_각각_8이다() {
+        let board = Board(pieces: [Position: Piece].initialPawns)
         
         let whiteScore = board.score(for: .white)
         let blackScore = board.score(for: .black)
@@ -120,8 +120,8 @@ final class BoardTests: XCTestCase {
         }
     }
     
-    func test초기상태의_board를_display할_수_있다() {
-        let board = Board(pieces: [Position: Piece].initialPieces)
+    func test폰이_초기화된_상태의_board를_display할_수_있다() {
+        let board = Board(pieces: [Position: Piece].initialPawns)
         let expect = """
 ........
 ♟♟♟♟♟♟♟♟
@@ -162,6 +162,24 @@ final class BoardTests: XCTestCase {
             "E2": Pawn(color: .white),
             "F4": Pawn(color: .white),
             "G6": Pawn(color: .white)
+        ]))
+    }
+    
+    func test검정색_Bishop_3개로_Board를_초기화_할_수_없다() {
+        var board = Board()
+        XCTAssertThrowsError(try board.updatePieces([
+            "A1": Bishop(color: .black),
+            "A4": Bishop(color: .black),
+            "B6": Bishop(color: .black)
+        ]))
+    }
+    
+    func test검정색_Rook_3개로_Board를_초기화_할_수_없다() {
+        var board = Board()
+        XCTAssertThrowsError(try board.updatePieces([
+            "A1": Rook(color: .black),
+            "A4": Rook(color: .black),
+            "B6": Rook(color: .black)
         ]))
     }
 }

--- a/ChessApp/ChessAppTests/Model/BoardTests.swift
+++ b/ChessApp/ChessAppTests/Model/BoardTests.swift
@@ -29,89 +29,97 @@ final class BoardTests: XCTestCase {
         XCTAssertEqual(blackScore, 0)
     }
     
-    func testA6가_빈칸일때_A7에_있는_백색Pawn을_A6으로_옮길_수_있다() {
+    func testA6가_빈칸일때_A7에_있는_백색Pawn을_A6으로_옮길_수_있다() throws {
         var board = Board(pieces: [
             "A7": Pawn(color: .white)
         ])
-        let result = board.move(from: "A7", to: "A6")
-        XCTAssertTrue(result)
+        try board.move(from: "A7", to: "A6")
         XCTAssertEqual(board.pieces["A6"]?.color, .white)
         XCTAssertNil(board.pieces["A7"])
     }
     
-    func testA7에_있는_백색Pawn을_2턴에_걸쳐_A5으로_옮길_수_있다() {
+    func testA7에_있는_백색Pawn을_2턴에_걸쳐_A5으로_옮길_수_있다() throws {
         var board = Board(pieces: [
             "A7": Pawn(color: .white)
         ])
-        let resultA6 = board.move(from: "A7", to: "A6")
-        let resultA5 = board.move(from: "A6", to: "A5")
-        XCTAssertTrue(resultA6)
-        XCTAssertTrue(resultA5)
+        try board.move(from: "A7", to: "A6")
+        try board.move(from: "A6", to: "A5")
         XCTAssertEqual(board.pieces["A5"]?.color, .white)
         XCTAssertNil(board.pieces["A6"])
         XCTAssertNil(board.pieces["A7"])
     }
     
-    func testA6에_흑색Pawn이_있을때_A7에_있는_백색Pawn을_A6으로_옮길_수_있다() {
+    func testA6에_흑색Pawn이_있을때_A7에_있는_백색Pawn을_A6으로_옮길_수_있다() throws {
         var board = Board(pieces: [
             "A6": Pawn(color: .black),
             "A7": Pawn(color: .white)
         ])
-        let result = board.move(from: "A7", to: "A6")
-        XCTAssertTrue(result)
+        try board.move(from: "A7", to: "A6")
         XCTAssertEqual(board.pieces["A6"]?.color, .white)
         XCTAssertNil(board.pieces["A7"])
     }
     
-    func testA6에_흑색Pawn이_있을때_A7에_있는_백색Pawn을_A6으로_옮겼다가_다시_A7로_옮길_수_없다() {
+    func testA6에_흑색Pawn이_있을때_A7에_있는_백색Pawn을_A6으로_옮겼다가_다시_A7로_옮길_수_없다() throws {
         var board = Board(pieces: [
             "A6": Pawn(color: .black),
             "A7": Pawn(color: .white)
         ])
-        _ = board.move(from: "A7", to: "A6")
-        let result = board.move(from: "A6", to: "A7")
-        XCTAssertFalse(result)
+        try board.move(from: "A7", to: "A6")
+        do {
+            try board.move(from: "A6", to: "A7")
+            XCTFail()
+        } catch {}
         XCTAssertEqual(board.pieces["A6"]?.color, .white)
         XCTAssertNil(board.pieces["A7"])
     }
     
-    func testA6에_백색Pawn이_있을때_A7에_있는_백색Pawn을_A6으로_옮길_수_없다() {
+    func testA6에_백색Pawn이_있을때_A7에_있는_백색Pawn을_A6으로_옮길_수_없다() throws {
         var board = Board(pieces: [
             "A6": Pawn(color: .white),
             "A7": Pawn(color: .white)
         ])
-        let result = board.move(from: "A7", to: "A6")
-        XCTAssertFalse(result)
+        do {
+            try board.move(from: "A7", to: "A6")
+            XCTFail()
+        } catch {}
     }
     
-    func testA7에_있는_백색Pawn을_A5으로_옮길_수_없다() {
+    func testA7에_있는_백색Pawn을_A5으로_옮길_수_없다() throws {
         var board = Board(pieces: [
             "A7": Pawn(color: .white)
         ])
-        let result = board.move(from: "A7", to: "A5")
-        XCTAssertFalse(result)
+        do {
+            try board.move(from: "A7", to: "A5")
+            XCTFail()
+        } catch {}
     }
     
-    func testA7에_있는_백색Pawn을_A8으로_옮길_수_없다() {
+    func testA7에_있는_백색Pawn을_A8으로_옮길_수_없다() throws {
         var board = Board(pieces: [
             "A7": Pawn(color: .white)
         ])
-        let result = board.move(from: "A7", to: "A8")
-        XCTAssertFalse(result)
+        do {
+            try board.move(from: "A7", to: "A8")
+            XCTFail()
+        } catch {}
     }
     
-    func testA7에_있는_흑색Pawn을_A6으로_옮길_수_없다() {
+    func testA7에_있는_흑색Pawn을_A6으로_옮길_수_없다() throws {
         var board = Board(pieces: [
             "A7": Pawn(color: .black)
         ])
-        let result = board.move(from: "A7", to: "A6")
-        XCTAssertFalse(result)
+        do {
+            try board.move(from: "A7", to: "A6")
+            XCTFail()
+        } catch {}
     }
     
-    func testA7에_말이_없을때_A6으로_옮길_수_없다() {
+    func testA7에_말이_없을때_A6으로_옮길_수_없다() throws {
         var board = Board(pieces: [:])
-        let result = board.move(from: "A7", to: "A6")
-        XCTAssertFalse(result)
+        do {
+            try board.move(from: "A7", to: "A6")
+            XCTFail()
+        } catch {}
     }
     
     func test초기상태의_board를_display할_수_있다() {

--- a/ChessApp/ChessAppTests/Model/BoardTests.swift
+++ b/ChessApp/ChessAppTests/Model/BoardTests.swift
@@ -33,9 +33,10 @@ final class BoardTests: XCTestCase {
         var board = Board(pieces: [
             "A7": Pawn(color: .white)
         ])
-        try board.move(from: "A7", to: "A6")
+        let didCaptured = try board.move(from: "A7", to: "A6")
         XCTAssertEqual(board.pieces["A6"]?.color, .white)
         XCTAssertNil(board.pieces["A7"])
+        XCTAssertFalse(didCaptured)
     }
     
     func testA7에_있는_백색Pawn을_2턴에_걸쳐_A5으로_옮길_수_있다() throws {
@@ -54,9 +55,10 @@ final class BoardTests: XCTestCase {
             "A6": Pawn(color: .black),
             "A7": Pawn(color: .white)
         ])
-        try board.move(from: "A7", to: "A6")
+        let didCaptured = try board.move(from: "A7", to: "A6")
         XCTAssertEqual(board.pieces["A6"]?.color, .white)
         XCTAssertNil(board.pieces["A7"])
+        XCTAssertTrue(didCaptured)
     }
     
     func testA6에_흑색Pawn이_있을때_A7에_있는_백색Pawn을_A6으로_옮겼다가_다시_A7로_옮길_수_없다() throws {

--- a/ChessApp/ChessAppTests/Model/BoardTests.swift
+++ b/ChessApp/ChessAppTests/Model/BoardTests.swift
@@ -206,17 +206,19 @@ final class BoardTests: XCTestCase {
         }
     }
     
-    func test폰과_룩_그리고_비숍이_초기화된_상태의_board를_display할_수_있다() {
+    func test킹을_제외한_말들이_초기화된_상태의_board를_display할_수_있다() {
         let pieces = [
             "A1": Rook(color: .black),
             "B1": Knight(color: .black),
             "C1": Bishop(color: .black),
+            "E1": Queen(color: .black),
             "F1": Bishop(color: .black),
             "G1": Knight(color: .black),
             "H1": Rook(color: .black),
             "A8": Rook(color: .white),
             "B8": Knight(color: .white),
             "C8": Bishop(color: .white),
+            "E8": Queen(color: .white),
             "F8": Bishop(color: .white),
             "G8": Knight(color: .white),
             "H8": Rook(color: .white)
@@ -224,14 +226,14 @@ final class BoardTests: XCTestCase {
         
         let board = Board(pieces: pieces)
         let expect = """
-♜♞♝..♝♞♜
+♜♞♝.♛♝♞♜
 ♟♟♟♟♟♟♟♟
 ........
 ........
 ........
 ........
 ♙♙♙♙♙♙♙♙
-♖♘♗..♗♘♖
+♖♘♗.♕♗♘♖
 """
         XCTAssertEqual(board.display(), expect)
     }

--- a/ChessApp/ChessAppTests/Model/BoardTests.swift
+++ b/ChessApp/ChessAppTests/Model/BoardTests.swift
@@ -209,25 +209,29 @@ final class BoardTests: XCTestCase {
     func test폰과_룩_그리고_비숍이_초기화된_상태의_board를_display할_수_있다() {
         let pieces = [
             "A1": Rook(color: .black),
+            "B1": Knight(color: .black),
             "C1": Bishop(color: .black),
             "F1": Bishop(color: .black),
+            "G1": Knight(color: .black),
             "H1": Rook(color: .black),
             "A8": Rook(color: .white),
+            "B8": Knight(color: .white),
             "C8": Bishop(color: .white),
             "F8": Bishop(color: .white),
+            "G8": Knight(color: .white),
             "H8": Rook(color: .white)
         ].merging([Position: Piece].initialPawns, uniquingKeysWith: { $1 })
         
         let board = Board(pieces: pieces)
         let expect = """
-♜.♝..♝.♜
+♜♞♝..♝♞♜
 ♟♟♟♟♟♟♟♟
 ........
 ........
 ........
 ........
 ♙♙♙♙♙♙♙♙
-♖.♗..♗.♖
+♖♘♗..♗♘♖
 """
         XCTAssertEqual(board.display(), expect)
     }

--- a/ChessApp/ChessAppTests/Model/BoardTests.swift
+++ b/ChessApp/ChessAppTests/Model/BoardTests.swift
@@ -162,6 +162,31 @@ final class BoardTests: XCTestCase {
         }
     }
     
+    func test폰과_룩_그리고_비숍이_초기화된_상태의_board를_display할_수_있다() {
+        let pieces = [
+            "A1": Rook(color: .black),
+            "C1": Bishop(color: .black),
+            "F1": Bishop(color: .black),
+            "H1": Rook(color: .black),
+            "A8": Rook(color: .white),
+            "C8": Bishop(color: .white),
+            "F8": Bishop(color: .white),
+            "H8": Rook(color: .white)
+        ].merging([Position: Piece].initialPawns, uniquingKeysWith: { $1 })
+        
+        let board = Board(pieces: pieces)
+        let expect = """
+♜.♝..♝.♜
+♟♟♟♟♟♟♟♟
+........
+........
+........
+........
+♙♙♙♙♙♙♙♙
+♖.♗..♗.♖
+"""
+    }
+    
     func test폰이_초기화된_상태의_board를_display할_수_있다() {
         let board = Board(pieces: [Position: Piece].initialPawns)
         let expect = """

--- a/ChessApp/ChessAppTests/Model/BoardTests.swift
+++ b/ChessApp/ChessAppTests/Model/BoardTests.swift
@@ -154,6 +154,50 @@ final class BoardTests: XCTestCase {
         }
     }
     
+    func testD4에_있는_흰색_Knight를_C6으로_옮길_수_있다() throws {
+        var board = Board(pieces: [
+            "D4": Knight(color: .white)
+        ])
+        
+        let didCaptured = try board.move(from: "D4", to: "C6")
+        XCTAssertEqual(board.pieces["C6"]?.color, .white)
+        XCTAssertNil(board.pieces["D4"])
+        XCTAssertFalse(didCaptured)
+    }
+    
+    func testD4에_있는_흰색_Knight를_D5로_옮길_수_없다() throws {
+        var board = Board(pieces: [
+            "D4": Knight(color: .white)
+        ])
+        
+        XCTAssertThrowsError(try board.move(from: "D4", to: "D5")) {
+            XCTAssertEqual($0 as? BoardMoveError, .invalidDestination)
+        }
+    }
+    
+    func testD5에_검정색Pawn이_있을떄_D4에_있는_흰색_Knight를_C6으로_옮길_수_없다() throws {
+        var board = Board(pieces: [
+            "D5": Pawn(color: .black),
+            "D4": Knight(color: .white)
+        ])
+        
+        XCTAssertThrowsError(try board.move(from: "D4", to: "C6")) {
+            XCTAssertEqual($0 as? BoardMoveError, .invalidDestination)
+        }
+    }
+    
+    func testC5에_검정색Pawn이_있을떄_D4에_있는_흰색_Knight를_C6으로_옮길_수_있다() throws {
+        var board = Board(pieces: [
+            "C5": Pawn(color: .black),
+            "D4": Knight(color: .white)
+        ])
+        
+        let didCaptured = try board.move(from: "D4", to: "C6")
+        XCTAssertEqual(board.pieces["C6"]?.color, .white)
+        XCTAssertNil(board.pieces["D4"])
+        XCTAssertFalse(didCaptured)
+    }
+
     func testA7에_말이_없을때_A6으로_옮길_수_없다() throws {
         var board = Board(pieces: [:])
         

--- a/ChessApp/ChessAppTests/Model/BoardTests.swift
+++ b/ChessApp/ChessAppTests/Model/BoardTests.swift
@@ -65,10 +65,9 @@ final class BoardTests: XCTestCase {
             "A7": Pawn(color: .white)
         ])
         try board.move(from: "A7", to: "A6")
-        do {
-            try board.move(from: "A6", to: "A7")
-            XCTFail()
-        } catch {}
+        XCTAssertThrowsError(try board.move(from: "A6", to: "A7")) {
+            XCTAssertEqual($0 as? BoardMoveError, .invalidDestination)
+        }
         XCTAssertEqual(board.pieces["A6"]?.color, .white)
         XCTAssertNil(board.pieces["A7"])
     }
@@ -78,48 +77,45 @@ final class BoardTests: XCTestCase {
             "A6": Pawn(color: .white),
             "A7": Pawn(color: .white)
         ])
-        do {
-            try board.move(from: "A7", to: "A6")
-            XCTFail()
-        } catch {}
+        XCTAssertThrowsError(try board.move(from: "A7", to: "A6")) {
+            XCTAssertEqual($0 as? BoardMoveError, .sameColor)
+        }
     }
     
     func testA7에_있는_백색Pawn을_A5으로_옮길_수_없다() throws {
         var board = Board(pieces: [
             "A7": Pawn(color: .white)
         ])
-        do {
-            try board.move(from: "A7", to: "A5")
-            XCTFail()
-        } catch {}
+        XCTAssertThrowsError(try board.move(from: "A7", to: "A5")) {
+            XCTAssertEqual($0 as? BoardMoveError, .invalidDestination)
+        }
     }
     
     func testA7에_있는_백색Pawn을_A8으로_옮길_수_없다() throws {
         var board = Board(pieces: [
             "A7": Pawn(color: .white)
         ])
-        do {
-            try board.move(from: "A7", to: "A8")
-            XCTFail()
-        } catch {}
+        XCTAssertThrowsError(try board.move(from: "A7", to: "A8")) {
+            XCTAssertEqual($0 as? BoardMoveError, .invalidDestination)
+        }
     }
     
     func testA7에_있는_흑색Pawn을_A6으로_옮길_수_없다() throws {
         var board = Board(pieces: [
             "A7": Pawn(color: .black)
         ])
-        do {
-            try board.move(from: "A7", to: "A6")
-            XCTFail()
-        } catch {}
+        
+        XCTAssertThrowsError(try board.move(from: "A7", to: "A6")) {
+            XCTAssertEqual($0 as? BoardMoveError, .invalidDestination)
+        }
     }
     
     func testA7에_말이_없을때_A6으로_옮길_수_없다() throws {
         var board = Board(pieces: [:])
-        do {
-            try board.move(from: "A7", to: "A6")
-            XCTFail()
-        } catch {}
+        
+        XCTAssertThrowsError(try board.move(from: "A7", to: "A6")) {
+            XCTAssertEqual($0 as? BoardMoveError, .invalidDestination)
+        }
     }
     
     func test초기상태의_board를_display할_수_있다() {
@@ -154,7 +150,7 @@ final class BoardTests: XCTestCase {
     
     func test흰색_Pawn_9개로_Board를_초기화_할_수_없다() {
         var board = Board()
-        let result = board.updatePieces([
+        XCTAssertThrowsError(try board.updatePieces([
             "A1": Pawn(color: .white),
             "A4": Pawn(color: .white),
             "B6": Pawn(color: .white),
@@ -164,7 +160,6 @@ final class BoardTests: XCTestCase {
             "E2": Pawn(color: .white),
             "F4": Pawn(color: .white),
             "G6": Pawn(color: .white)
-        ])
-        XCTAssertFalse(result)
+        ]))
     }
 }

--- a/ChessApp/ChessAppTests/Model/BoardTests.swift
+++ b/ChessApp/ChessAppTests/Model/BoardTests.swift
@@ -112,6 +112,48 @@ final class BoardTests: XCTestCase {
         }
     }
     
+    func testC6에_검정색Pawn이_있을때_D5에_있는_흰색_Bishop을_C6으로_옮길_수_있다() throws {
+        var board = Board(pieces: [
+            "C6": Pawn(color: .black),
+            "D5": Bishop(color: .white)
+        ])
+        let isCaptured = try board.move(from: "D5", to: "C6")
+        XCTAssertTrue(isCaptured)
+        XCTAssertEqual(board.pieces["C6"]?.color, .white)
+        XCTAssertNil(board.pieces["D5"])
+    }
+    
+    func testC6에_검정색Pawn이_있을때_D5에_있는_흰색_Bishop을_A8으로_옮길_수_없다() throws {
+        var board = Board(pieces: [
+            "C6": Pawn(color: .black),
+            "D5": Bishop(color: .white)
+        ])
+        XCTAssertThrowsError(try board.move(from: "D5", to: "A8")) {
+            XCTAssertEqual($0 as? BoardMoveError, .invalidDestination)
+        }
+    }
+    
+    func testC6에_검정색Pawn이_있을때_D6에_있는_흰색_Rook을_C6으로_옮길_수_있다() throws {
+        var board = Board(pieces: [
+            "C6": Pawn(color: .black),
+            "D6": Rook(color: .white)
+        ])
+        let isCaptured = try board.move(from: "D6", to: "C6")
+        XCTAssertTrue(isCaptured)
+        XCTAssertEqual(board.pieces["C6"]?.color, .white)
+        XCTAssertNil(board.pieces["D6"])
+    }
+    
+    func testC6에_검정색Pawn이_있을때_D6에_있는_흰색_Rook을_A6으로_옮길_수_없다() throws {
+        var board = Board(pieces: [
+            "C6": Pawn(color: .black),
+            "D6": Rook(color: .white)
+        ])
+        XCTAssertThrowsError(try board.move(from: "D6", to: "A6")) {
+            XCTAssertEqual($0 as? BoardMoveError, .invalidDestination)
+        }
+    }
+    
     func testA7에_말이_없을때_A6으로_옮길_수_없다() throws {
         var board = Board(pieces: [:])
         

--- a/ChessApp/ChessAppTests/Model/BoardTests.swift
+++ b/ChessApp/ChessAppTests/Model/BoardTests.swift
@@ -202,7 +202,7 @@ final class BoardTests: XCTestCase {
         var board = Board(pieces: [:])
         
         XCTAssertThrowsError(try board.move(from: "A7", to: "A6")) {
-            XCTAssertEqual($0 as? BoardMoveError, .invalidDestination)
+            XCTAssertEqual($0 as? BoardMoveError, .invalidStartingPoint)
         }
     }
     
@@ -229,6 +229,7 @@ final class BoardTests: XCTestCase {
 ♙♙♙♙♙♙♙♙
 ♖.♗..♗.♖
 """
+        XCTAssertEqual(board.display(), expect)
     }
     
     func test폰이_초기화된_상태의_board를_display할_수_있다() {

--- a/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
@@ -18,10 +18,10 @@ final class BishopTests: XCTestCase {
         let bishop = Bishop(color: .white)
         let availablePositions = bishop.availableMovingWays(for: "D5")
         XCTAssertEqual(availablePositions, [
-            PieceMovingWay(rawValue: ["C6", "B7", "A8"]),
-            PieceMovingWay(rawValue: ["E6", "F7", "G8"]),
-            PieceMovingWay(rawValue: ["C4", "B3", "A2"]),
-            PieceMovingWay(rawValue: ["E4", "F3", "G2", "H1"])
+            PieceMovingWay(positions: ["C6", "B7", "A8"]),
+            PieceMovingWay(positions: ["E6", "F7", "G8"]),
+            PieceMovingWay(positions: ["C4", "B3", "A2"]),
+            PieceMovingWay(positions: ["E4", "F3", "G2", "H1"])
         ])
     }
     
@@ -29,8 +29,8 @@ final class BishopTests: XCTestCase {
         let bishop = Bishop(color: .black)
         let availablePositions = bishop.availableMovingWays(for: "H8")
         XCTAssertEqual(availablePositions, [
-            PieceMovingWay(rawValue: ["G7", "F6", "E5", "D4", "C3", "B2", "A1"]),
-            PieceMovingWay(rawValue: [])
+            PieceMovingWay(positions: ["G7", "F6", "E5", "D4", "C3", "B2", "A1"]),
+            PieceMovingWay(positions: [])
         ])
     }
 }

--- a/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
@@ -10,8 +10,7 @@ import XCTest
 
 final class BishopTests: XCTestCase {
     func testBishop의_점수는_3점이다() {
-        let bishop = Bishop(color: .white)
-        XCTAssertEqual(bishop.score, 3)
+        XCTAssertEqual(Bishop.score, 3)
     }
     
     func testD5에_있는_흰색_비숍의_움직일_수_있는_위치를_확인한다() {

--- a/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
@@ -16,20 +16,21 @@ final class BishopTests: XCTestCase {
     
     func testD5에_있는_흰색_비숍의_움직일_수_있는_위치를_확인한다() {
         let bishop = Bishop(color: .white)
-        let availablePositions = bishop.availableMovePositions(for: "D5")
+        let availablePositions = bishop.availableMovingWays(for: "D5")
         XCTAssertEqual(availablePositions, [
-            "A8", "B7", "C6",
-            "G8", "F7", "E6",
-            "A2", "B3", "C4",
-            "H1", "G2", "F3", "E4"
+            PieceMovingWay(rawValue: ["C6", "B7", "A8"]),
+            PieceMovingWay(rawValue: ["E6", "F7", "G8"]),
+            PieceMovingWay(rawValue: ["C4", "B3", "A2"]),
+            PieceMovingWay(rawValue: ["E4", "F3", "G2", "H1"])
         ])
     }
     
     func testH8에_있는_검정색_비숍의_움직일_수_있는_위치를_확인한다() {
         let bishop = Bishop(color: .black)
-        let availablePositions = bishop.availableMovePositions(for: "H8")
+        let availablePositions = bishop.availableMovingWays(for: "H8")
         XCTAssertEqual(availablePositions, [
-            "A1", "B2", "C3", "D4", "E5", "F6", "G7"
+            PieceMovingWay(rawValue: ["G7", "F6", "E5", "D4", "C3", "B2", "A1"]),
+            PieceMovingWay(rawValue: [])
         ])
     }
 }

--- a/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
@@ -1,0 +1,30 @@
+//
+//  BishopTests.swift
+//  ChessAppTests
+//
+//  Created by 현기엽 on 2023/10/20.
+//
+
+import XCTest
+@testable import ChessApp
+
+final class BishopTests: XCTestCase {
+    func testD5에_있는_흰색_비숍의_움직일_수_있는_위치를_확인한다() {
+        let bishop = Bishop(color: .white)
+        let availablePositions = bishop.availableMovePositions(for: "D5")
+        XCTAssertEqual(availablePositions, [
+            "A8", "B7", "C6",
+            "G8", "F7", "E6",
+            "A2", "B3", "D4",
+            "H1", "G2", "F3", "E4"
+        ])
+    }
+    
+    func testH8에_있는_검정색_비숍의_움직일_수_있는_위치를_확인한다() {
+        let bishop = Bishop(color: .black)
+        let availablePositions = bishop.availableMovePositions(for: "H8")
+        XCTAssertEqual(availablePositions, [
+            "A1", "B2", "C3", "D4", "E5", "F6", "G7"
+        ])
+    }
+}

--- a/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
@@ -18,10 +18,10 @@ final class BishopTests: XCTestCase {
         let bishop = Bishop(color: .white)
         let availablePositions = bishop.availableMovingWays(for: "D5")
         XCTAssertEqual(availablePositions, [
-            PieceMovingWay(positions: ["C6", "B7", "A8"]),
-            PieceMovingWay(positions: ["E6", "F7", "G8"]),
-            PieceMovingWay(positions: ["C4", "B3", "A2"]),
-            PieceMovingWay(positions: ["E4", "F3", "G2", "H1"])
+            ["C6", "B7", "A8"],
+            ["E6", "F7", "G8"],
+            ["C4", "B3", "A2"],
+            ["E4", "F3", "G2", "H1"]
         ])
     }
     
@@ -29,8 +29,8 @@ final class BishopTests: XCTestCase {
         let bishop = Bishop(color: .black)
         let availablePositions = bishop.availableMovingWays(for: "H8")
         XCTAssertEqual(availablePositions, [
-            PieceMovingWay(positions: ["G7", "F6", "E5", "D4", "C3", "B2", "A1"]),
-            PieceMovingWay(positions: [])
+            ["G7", "F6", "E5", "D4", "C3", "B2", "A1"],
+            []
         ])
     }
 }

--- a/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
@@ -9,6 +9,11 @@ import XCTest
 @testable import ChessApp
 
 final class BishopTests: XCTestCase {
+    func testBishop의_점수는_3점이다() {
+        let bishop = Bishop(color: .white)
+        XCTAssertEqual(bishop.score, 3)
+    }
+    
     func testD5에_있는_흰색_비숍의_움직일_수_있는_위치를_확인한다() {
         let bishop = Bishop(color: .white)
         let availablePositions = bishop.availableMovePositions(for: "D5")

--- a/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/BishopTests.swift
@@ -20,7 +20,7 @@ final class BishopTests: XCTestCase {
         XCTAssertEqual(availablePositions, [
             "A8", "B7", "C6",
             "G8", "F7", "E6",
-            "A2", "B3", "D4",
+            "A2", "B3", "C4",
             "H1", "G2", "F3", "E4"
         ])
     }

--- a/ChessApp/ChessAppTests/Model/Pieces/KnightTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/KnightTests.swift
@@ -10,8 +10,7 @@ import XCTest
 
 final class KnightTests: XCTestCase {
     func testKnight의_점수는_3점이다() {
-        let knight = Knight(color: .white)
-        XCTAssertEqual(knight.score, 3)
+        XCTAssertEqual(Knight.score, 3)
     }
     
     func testD5에_있는_흰색_나이트의_움직일_수_있는_위치를_확인한다() {

--- a/ChessApp/ChessAppTests/Model/Pieces/KnightTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/KnightTests.swift
@@ -1,0 +1,25 @@
+//
+//  KnightTests.swift
+//  ChessAppTests
+//
+//  Created by 현기엽 on 2023/10/21.
+//
+
+import XCTest
+@testable import ChessApp
+
+final class KnightTests: XCTestCase {
+    func testKnight의_점수는_3점이다() {
+        let knight = Knight(color: .white)
+        XCTAssertEqual(knight.score, 3)
+    }
+    
+    func testD5에_있는_흰색_나이트의_움직일_수_있는_위치를_확인한다() {
+        let rook = Rook(color: .white)
+        let availablePositions = rook.availableMovingWays(for: "D5")
+        XCTAssertEqual(availablePositions, [
+            ["C5", "B5", "A5"], ["E5", "F5", "G5", "H5"],
+            ["D4", "D3", "D2", "D1"], ["D6", "D7", "D8"]
+        ])
+    }
+}

--- a/ChessApp/ChessAppTests/Model/Pieces/PawnTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/PawnTests.swift
@@ -10,23 +10,23 @@ import XCTest
 
 final class PawnTests: XCTestCase {
     func testA7에_있는_흑색Pawn의_이동가능한_위치는_A8이다() {
-        let pawn = Pawn(color: .black, position: "A7")
-        XCTAssertEqual(pawn.availableMovePositions, ["A8"])
+        let pawn = Pawn(color: .black)
+        XCTAssertEqual(pawn.availableMovePositions(for: "A7"), ["A8"])
     }
     
     func testA7에_있는_백색Pawn의_이동가능한_위치는_A6이다() {
-        let pawn = Pawn(color: .white, position: "A7")
-        XCTAssertEqual(pawn.availableMovePositions, ["A6"])
+        let pawn = Pawn(color: .white)
+        XCTAssertEqual(pawn.availableMovePositions(for: "A7"), ["A6"])
     }
     
     func testA8에_있는_흑색Pawn의_이동가능한_위치는_없다() {
-        let pawn = Pawn(color: .black, position: "A8")
-        XCTAssertEqual(pawn.availableMovePositions, [])
+        let pawn = Pawn(color: .black)
+        XCTAssertEqual(pawn.availableMovePositions(for: "A8"), [])
     }
     
     func testA1에_있는_백색Pawn의_이동가능한_위치는_없다() {
-        let pawn = Pawn(color: .white, position: "A1")
-        XCTAssertEqual(pawn.availableMovePositions, [])
+        let pawn = Pawn(color: .white)
+        XCTAssertEqual(pawn.availableMovePositions(for: "A1"), [])
     }
     
 }

--- a/ChessApp/ChessAppTests/Model/Pieces/PawnTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/PawnTests.swift
@@ -11,22 +11,22 @@ import XCTest
 final class PawnTests: XCTestCase {
     func testA7에_있는_흑색Pawn의_이동가능한_위치는_A8이다() {
         let pawn = Pawn(color: .black)
-        XCTAssertEqual(pawn.availableMovePositions(for: "A7"), ["A8"])
+        XCTAssertEqual(pawn.availableMovingWays(for: "A7"), [["A8"]])
     }
     
     func testA7에_있는_백색Pawn의_이동가능한_위치는_A6이다() {
         let pawn = Pawn(color: .white)
-        XCTAssertEqual(pawn.availableMovePositions(for: "A7"), ["A6"])
+        XCTAssertEqual(pawn.availableMovingWays(for: "A7"), [["A6"]])
     }
     
     func testA8에_있는_흑색Pawn의_이동가능한_위치는_없다() {
         let pawn = Pawn(color: .black)
-        XCTAssertEqual(pawn.availableMovePositions(for: "A8"), [])
+        XCTAssertEqual(pawn.availableMovingWays(for: "A8"), [])
     }
     
     func testA1에_있는_백색Pawn의_이동가능한_위치는_없다() {
         let pawn = Pawn(color: .white)
-        XCTAssertEqual(pawn.availableMovePositions(for: "A1"), [])
+        XCTAssertEqual(pawn.availableMovingWays(for: "A1"), [])
     }
     
 }

--- a/ChessApp/ChessAppTests/Model/Pieces/QueenTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/QueenTests.swift
@@ -10,8 +10,7 @@ import XCTest
 
 final class QueenTests: XCTestCase {
     func testQueen의_점수는_9점이다() {
-        let queen = Queen(color: .white)
-        XCTAssertEqual(queen.score, 9)
+        XCTAssertEqual(Queen.score, 9)
     }
     
     func testD5에_있는_흰색_퀸의_움직일_수_있는_위치를_확인한다() {

--- a/ChessApp/ChessAppTests/Model/Pieces/QueenTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/QueenTests.swift
@@ -1,0 +1,40 @@
+//
+//  QueenTests.swift
+//  ChessAppTests
+//
+//  Created by 현기엽 on 2023/10/22.
+//
+
+import XCTest
+@testable import ChessApp
+
+final class QueenTests: XCTestCase {
+    func testQueen의_점수는_9점이다() {
+        let queen = Queen(color: .white)
+        XCTAssertEqual(queen.score, 9)
+    }
+    
+    func testD5에_있는_흰색_퀸의_움직일_수_있는_위치를_확인한다() {
+        let queen = Queen(color: .white)
+        let availablePositions = queen.availableMovingWays(for: "D5")
+        XCTAssertEqual(availablePositions, [
+            ["C6", "B7", "A8"],
+            ["E6", "F7", "G8"],
+            ["C4", "B3", "A2"],
+            ["E4", "F3", "G2", "H1"],
+            ["C5", "B5", "A5"], ["E5", "F5", "G5", "H5"],
+            ["D4", "D3", "D2", "D1"], ["D6", "D7", "D8"]
+        ])
+    }
+    
+    func testH8에_있는_검정색_퀸의_움직일_수_있는_위치를_확인한다() {
+        let queen = Queen(color: .black)
+        let availablePositions = queen.availableMovingWays(for: "H8")
+        XCTAssertEqual(availablePositions, [
+            ["G7", "F6", "E5", "D4", "C3", "B2", "A1"],
+            [],
+            ["G8", "F8", "E8", "D8", "C8", "B8", "A8"],
+            ["H7", "H6", "H5", "H4", "H3", "H2", "H1"]
+        ])
+    }
+}

--- a/ChessApp/ChessAppTests/Model/Pieces/RookTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/RookTests.swift
@@ -10,8 +10,7 @@ import XCTest
 
 final class RookTests: XCTestCase {
     func testRook의_점수는_5점이다() {
-        let rook = Rook(color: .white)
-        XCTAssertEqual(rook.score, 5)
+        XCTAssertEqual(Rook.score, 5)
     }
     
     func testD5에_있는_흰색_룩의_움직일_수_있는_위치를_확인한다() {

--- a/ChessApp/ChessAppTests/Model/Pieces/RookTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/RookTests.swift
@@ -28,7 +28,6 @@ final class RookTests: XCTestCase {
         let availablePositions = rook.availableMovingWays(for: "H8")
         XCTAssertEqual(availablePositions, [
             [],
-            [],
             ["G8", "F8", "E8", "D8", "C8", "B8", "A8"],
             ["H7", "H6", "H5", "H4", "H3", "H2", "H1"]
         ])

--- a/ChessApp/ChessAppTests/Model/Pieces/RookTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/RookTests.swift
@@ -9,6 +9,11 @@ import XCTest
 @testable import ChessApp
 
 final class RookTests: XCTestCase {
+    func testRook의_점수는_5점이다() {
+        let rook = Rook(color: .white)
+        XCTAssertEqual(rook.score, 5)
+    }
+    
     func testD5에_있는_흰색_룩의_움직일_수_있는_위치를_확인한다() {
         let rook = Rook(color: .white)
         let availablePositions = rook.availableMovePositions(for: "D5")

--- a/ChessApp/ChessAppTests/Model/Pieces/RookTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/RookTests.swift
@@ -16,19 +16,21 @@ final class RookTests: XCTestCase {
     
     func testD5에_있는_흰색_룩의_움직일_수_있는_위치를_확인한다() {
         let rook = Rook(color: .white)
-        let availablePositions = rook.availableMovePositions(for: "D5")
+        let availablePositions = rook.availableMovingWays(for: "D5")
         XCTAssertEqual(availablePositions, [
-            "A5", "B5", "C5", "E5", "F5", "G5", "H5",
-            "D1", "D2", "D3", "D4", "D6", "D7", "D8"
+            ["C5", "B5", "A5"], ["E5", "F5", "G5", "H5"],
+            ["D4", "D3", "D2", "D1"], ["D6", "D7", "D8"]
         ])
     }
     
     func testH8에_있는_검정색_룩의_움직일_수_있는_위치를_확인한다() {
         let rook = Rook(color: .black)
-        let availablePositions = rook.availableMovePositions(for: "H8")
+        let availablePositions = rook.availableMovingWays(for: "H8")
         XCTAssertEqual(availablePositions, [
-            "A8", "B8", "C8", "D8", "E8", "F8", "G8",
-            "H1", "H2", "H3", "H4", "H5", "H6", "H7"
+            [],
+            [],
+            ["G8", "F8", "E8", "D8", "C8", "B8", "A8"],
+            ["H7", "H6", "H5", "H4", "H3", "H2", "H1"]
         ])
     }
 }

--- a/ChessApp/ChessAppTests/Model/Pieces/RookTests.swift
+++ b/ChessApp/ChessAppTests/Model/Pieces/RookTests.swift
@@ -1,0 +1,29 @@
+//
+//  RookTests.swift
+//  ChessAppTests
+//
+//  Created by 현기엽 on 2023/10/21.
+//
+
+import XCTest
+@testable import ChessApp
+
+final class RookTests: XCTestCase {
+    func testD5에_있는_흰색_룩의_움직일_수_있는_위치를_확인한다() {
+        let rook = Rook(color: .white)
+        let availablePositions = rook.availableMovePositions(for: "D5")
+        XCTAssertEqual(availablePositions, [
+            "A5", "B5", "C5", "E5", "F5", "G5", "H5",
+            "D1", "D2", "D3", "D4", "D6", "D7", "D8"
+        ])
+    }
+    
+    func testH8에_있는_검정색_룩의_움직일_수_있는_위치를_확인한다() {
+        let rook = Rook(color: .black)
+        let availablePositions = rook.availableMovePositions(for: "H8")
+        XCTAssertEqual(availablePositions, [
+            "A8", "B8", "C8", "D8", "E8", "F8", "G8",
+            "H1", "H2", "H3", "H4", "H5", "H6", "H7"
+        ])
+    }
+}

--- a/ChessApp/ChessAppTests/TestExtensions/Piece+Test.swift
+++ b/ChessApp/ChessAppTests/TestExtensions/Piece+Test.swift
@@ -10,10 +10,12 @@ import Foundation
 import XCTest
 
 extension [Position: Piece] {
-    static var initialPieces: [Position: Piece] {
-        Position.File.range.reduce([:]) { (partialResult: [Position: Piece], i: UInt8) -> [Position: Piece] in
+    static var initialPawns: [Position: Piece] {
+        Position.File.range.reduce([:]) { (partialResult: [Position: Piece], i: Int) -> [Position: Piece] in
+            guard let file = UnicodeScalar(65 + i) else { // "A" + i
+                return partialResult
+            }
             var partialResult = partialResult
-            let file = String(UnicodeScalar(65 + i)) // "A" + i
             if let blackPawnPosition = Position("\(file)2") {
                 partialResult[blackPawnPosition] = Pawn(color: .black)
             }

--- a/ChessApp/ChessAppTests/TestExtensions/Piece+Test.swift
+++ b/ChessApp/ChessAppTests/TestExtensions/Piece+Test.swift
@@ -9,28 +9,18 @@ import Foundation
 @testable import ChessApp
 import XCTest
 
-extension Board {
-    init(pieces: [Piece]) {
-        var board = Board()
-        if board.updatePieces(pieces) == false {
-            XCTFail("pieces를 update할 수 없음")
-        }
-        self = board
-    }
-}
-
-extension [Piece] {
-    static var initialPieces: [Piece] {
-        Position.File.range.flatMap { (i: UInt8) in
+extension [Position: Piece] {
+    static var initialPieces: [Position: Piece] {
+        Position.File.range.reduce([:]) { (partialResult: [Position: Piece], i: UInt8) -> [Position: Piece] in
+            var partialResult = partialResult
             let file = String(UnicodeScalar(65 + i)) // "A" + i
-            let pawn = { (color: Color, position: String) -> Pawn? in
-                guard let position = Position(position) else { return nil }
-                return Pawn(color: color, position: position)
+            if let blackPawnPosition = Position("\(file)2") {
+                partialResult[blackPawnPosition] = Pawn(color: .black)
             }
-            return [
-                pawn(.black, "\(file)2"),
-                pawn(.white, "\(file)7")
-            ].compactMap { $0 }
+            if let whitePawnPosition = Position("\(file)7") {
+                partialResult[whitePawnPosition] = Pawn(color: .white)
+            }
+            return partialResult
         }
     }
 }


### PR DESCRIPTION
### 개요
- Bishop, Rook, Queen, Knight 구현

- 기존 1칸만 이동하는 Pawn에 비해 여러칸을 한번에 이동하는 Piece이다보니 이동할 수 있는 목적지만 가지고 여러가지 요구사항을 구현하기에는 한계가 있었음
=> PieceMovingWay 구현
기물이 움직일 수 있는 길을 추상화한 struct로 중간에 다른 기물이 있는지, 지나갈 수는 있지만 멈출 수 없는 지점인지(나이트) 등을 판단하는 객체로 설계

- 기존 Position의 경우 Rank와 File이 모두 failable initializer를 갖고 있었기 때문에 말이 이동된 다른 위치를 계산하기에 번거로움이 많고 가독성이 좋지 않아 ```func offsetBy(fileOffset: Int, rankOffset: Int) -> Position?``` 메서드를 구현

그 결과 Bishop, Rook, Queen은 나름 일관성 있는 구조의 코드를 갖게 되었으나
Knight의 경우 아직 중복된 코드 구조가 있는 것 같아 개선의 여지가 남아있는 것 같습니다.