### PR TITLE
체스보드와 Pawn

### DIFF
--- a/chess-app/chess-app.xcodeproj/project.pbxproj
+++ b/chess-app/chess-app.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		739CE6BB2AE52B12009FD513 /* Pieces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739CE6BA2AE52B12009FD513 /* Pieces.swift */; };
 		739CE6BD2AE540D3009FD513 /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739CE6BC2AE540D3009FD513 /* Board.swift */; };
 		739CE6BF2AE54136009FD513 /* Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739CE6BE2AE54136009FD513 /* Position.swift */; };
+		739CE6C02AE7E007009FD513 /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739CE6BC2AE540D3009FD513 /* Board.swift */; };
+		739CE6C22AE7E26A009FD513 /* Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739CE6BE2AE54136009FD513 /* Position.swift */; };
+		739CE6C32AE7E26D009FD513 /* Pieces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739CE6BA2AE52B12009FD513 /* Pieces.swift */; };
 		73DB20972ADBB91E00376571 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB20962ADBB91E00376571 /* AppDelegate.swift */; };
 		73DB20992ADBB91E00376571 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB20982ADBB91E00376571 /* SceneDelegate.swift */; };
 		73DB209B2ADBB91E00376571 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB209A2ADBB91E00376571 /* ViewController.swift */; };
@@ -300,7 +303,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				739CE6C32AE7E26D009FD513 /* Pieces.swift in Sources */,
+				739CE6C02AE7E007009FD513 /* Board.swift in Sources */,
 				73DB20AE2ADBB91F00376571 /* chess_appTests.swift in Sources */,
+				739CE6C22AE7E26A009FD513 /* Position.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/chess-app/chess-app.xcodeproj/project.pbxproj
+++ b/chess-app/chess-app.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		739CE6B72AE52AE3009FD513 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 739CE6B62AE52AE3009FD513 /* SnapKit */; };
+		739CE6BB2AE52B12009FD513 /* Pieces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739CE6BA2AE52B12009FD513 /* Pieces.swift */; };
 		73DB20972ADBB91E00376571 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB20962ADBB91E00376571 /* AppDelegate.swift */; };
 		73DB20992ADBB91E00376571 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB20982ADBB91E00376571 /* SceneDelegate.swift */; };
 		73DB209B2ADBB91E00376571 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB209A2ADBB91E00376571 /* ViewController.swift */; };
@@ -35,6 +37,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		739CE6BA2AE52B12009FD513 /* Pieces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pieces.swift; sourceTree = "<group>"; };
 		73DB20932ADBB91E00376571 /* chess-app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "chess-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		73DB20962ADBB91E00376571 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		73DB20982ADBB91E00376571 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -54,6 +57,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				739CE6B72AE52AE3009FD513 /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,6 +104,7 @@
 				73DB209A2ADBB91E00376571 /* ViewController.swift */,
 				73DB20C72ADBBA0400376571 /* Application */,
 				73DB20C62ADBB96100376571 /* Resources */,
+				739CE6BA2AE52B12009FD513 /* Pieces.swift */,
 			);
 			path = "chess-app";
 			sourceTree = "<group>";
@@ -156,6 +161,9 @@
 			dependencies = (
 			);
 			name = "chess-app";
+			packageProductDependencies = (
+				739CE6B62AE52AE3009FD513 /* SnapKit */,
+			);
 			productName = "chess-app";
 			productReference = 73DB20932ADBB91E00376571 /* chess-app.app */;
 			productType = "com.apple.product-type.application";
@@ -228,6 +236,9 @@
 				Base,
 			);
 			mainGroup = 73DB208A2ADBB91E00376571;
+			packageReferences = (
+				739CE6B52AE52AE3009FD513 /* XCRemoteSwiftPackageReference "SnapKit" */,
+			);
 			productRefGroup = 73DB20942ADBB91E00376571 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -270,6 +281,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				739CE6BB2AE52B12009FD513 /* Pieces.swift in Sources */,
 				73DB209B2ADBB91E00376571 /* ViewController.swift in Sources */,
 				73DB20972ADBB91E00376571 /* AppDelegate.swift in Sources */,
 				73DB20992ADBB91E00376571 /* SceneDelegate.swift in Sources */,
@@ -604,6 +616,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		739CE6B52AE52AE3009FD513 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
+			requirement = {
+				branch = develop;
+				kind = branch;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		739CE6B62AE52AE3009FD513 /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 739CE6B52AE52AE3009FD513 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 73DB208B2ADBB91E00376571 /* Project object */;
 }

--- a/chess-app/chess-app.xcodeproj/project.pbxproj
+++ b/chess-app/chess-app.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		739CE6B72AE52AE3009FD513 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 739CE6B62AE52AE3009FD513 /* SnapKit */; };
 		739CE6BB2AE52B12009FD513 /* Pieces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739CE6BA2AE52B12009FD513 /* Pieces.swift */; };
+		739CE6BD2AE540D3009FD513 /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739CE6BC2AE540D3009FD513 /* Board.swift */; };
+		739CE6BF2AE54136009FD513 /* Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = 739CE6BE2AE54136009FD513 /* Position.swift */; };
 		73DB20972ADBB91E00376571 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB20962ADBB91E00376571 /* AppDelegate.swift */; };
 		73DB20992ADBB91E00376571 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB20982ADBB91E00376571 /* SceneDelegate.swift */; };
 		73DB209B2ADBB91E00376571 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73DB209A2ADBB91E00376571 /* ViewController.swift */; };
@@ -38,6 +40,8 @@
 
 /* Begin PBXFileReference section */
 		739CE6BA2AE52B12009FD513 /* Pieces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pieces.swift; sourceTree = "<group>"; };
+		739CE6BC2AE540D3009FD513 /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
+		739CE6BE2AE54136009FD513 /* Position.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Position.swift; sourceTree = "<group>"; };
 		73DB20932ADBB91E00376571 /* chess-app.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "chess-app.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		73DB20962ADBB91E00376571 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		73DB20982ADBB91E00376571 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -104,6 +108,8 @@
 				73DB209A2ADBB91E00376571 /* ViewController.swift */,
 				73DB20C72ADBBA0400376571 /* Application */,
 				73DB20C62ADBB96100376571 /* Resources */,
+				739CE6BC2AE540D3009FD513 /* Board.swift */,
+				739CE6BE2AE54136009FD513 /* Position.swift */,
 				739CE6BA2AE52B12009FD513 /* Pieces.swift */,
 			);
 			path = "chess-app";
@@ -283,6 +289,8 @@
 			files = (
 				739CE6BB2AE52B12009FD513 /* Pieces.swift in Sources */,
 				73DB209B2ADBB91E00376571 /* ViewController.swift in Sources */,
+				739CE6BF2AE54136009FD513 /* Position.swift in Sources */,
+				739CE6BD2AE540D3009FD513 /* Board.swift in Sources */,
 				73DB20972ADBB91E00376571 /* AppDelegate.swift in Sources */,
 				73DB20992ADBB91E00376571 /* SceneDelegate.swift in Sources */,
 			);

--- a/chess-app/chess-app/Board.swift
+++ b/chess-app/chess-app/Board.swift
@@ -67,7 +67,26 @@ final class Board {
     }
     
     /// 말 이동 가능 여부 파악
-    private func move(from: Position, to: Position) -> Bool {
+    private func canMove(from: Position, to: Position) -> Bool {
+        let prevColor = chessBoard[from.file][from.rank].color
+        let currentColor = chessBoard[to.file][to.rank].color
+        
+        // 현재 보드의 from 좌표 값이 비어있는지 확인
+        guard prevColor == .none else {
+            return false
+        }
+        
+        // 이동할 위치의 말이 현재 말과 같은지 확인
+        guard prevColor != currentColor else {
+            return false
+        }
+        
         return true
+    }
+    
+    /// 말 이동
+    private func move(from: Position, to: Position)  {
+        chessBoard[to.file][to.rank] = chessBoard[from.file][from.rank]
+        chessBoard[to.file][to.rank] = .init(type: .none, color: .none)
     }
 }

--- a/chess-app/chess-app/Board.swift
+++ b/chess-app/chess-app/Board.swift
@@ -12,6 +12,9 @@ import Foundation
 final class Board {
     private let size = 8
     private var chessBoard = [[Piece]]()
+    private var player: PieceColor = .white
+    
+    // MARK: - Initialize
     
     init() {
         reset()
@@ -47,7 +50,7 @@ final class Board {
             .insert(Array(repeating: blackPwan,
                           count: size
                          ), at: Rank.two.number
-            ) 
+            )
         
         chessBoard
             .insert(Array(repeating: whitePwan,
@@ -55,8 +58,42 @@ final class Board {
                          ), at: Rank.seven.number
             )
     }
- 
-    /// 현재 보드 상태 출력
+    
+    // MARK: - Move Method
+    
+    /// 말 이동
+    private func movePiece(piece: Piece, from: Position, to: Position) {
+        guard piece.color == player else { return }
+        guard validateMove(piece: piece, from: from, to: to) else { return }
+        guard move(from: from, to: to) else { return }
+        
+        chessBoard[to.file][to.rank] = chessBoard[from.file][from.rank]
+        chessBoard[from.file][from.rank] = .init(type: .none, color: .none)
+        changPlayer()
+    }
+    
+    /// 이동 가능한 범위인지 확인
+    private func validateMove(piece: Piece, from: Position, to: Position) -> Bool {
+        let distance: MovableRange = .init(file: from.file - to.file, rank: from.rank - to.rank)
+        return distance == piece.movableRange
+    }
+    
+    /// 말 이동 가능 여부 파악
+    private func move(from: Position, to: Position) -> Bool {
+        let currentColor = getPiece(position: from).color
+        let nextColor = getPiece(position: to).color
+        
+        guard currentColor != .none,
+              currentColor != nextColor else {
+            return false
+        }
+        
+        return true
+    }
+    
+    // MARK: - Method
+    
+    /// 현재 보드 상태
     private func display() -> [[String]] {
         chessBoard
             .map { file in
@@ -66,27 +103,13 @@ final class Board {
             }
     }
     
-    /// 말 이동 가능 여부 파악
-    private func canMove(from: Position, to: Position) -> Bool {
-        let prevColor = chessBoard[from.file][from.rank].color
-        let currentColor = chessBoard[to.file][to.rank].color
-        
-        // 현재 보드의 from 좌표 값이 비어있는지 확인
-        guard prevColor == .none else {
-            return false
-        }
-        
-        // 이동할 위치의 말이 현재 말과 같은지 확인
-        guard prevColor != currentColor else {
-            return false
-        }
-        
-        return true
+    /// 특정 위치의 말
+    private func getPiece(position: Position) -> Piece {
+        chessBoard[position.file][position.rank]
     }
     
-    /// 말 이동
-    private func move(from: Position, to: Position)  {
-        chessBoard[to.file][to.rank] = chessBoard[from.file][from.rank]
-        chessBoard[to.file][to.rank] = .init(type: .none, color: .none)
+    /// 순서 변경
+    private func changPlayer() {
+        player = (player == .white) ? .black : .white
     }
 }

--- a/chess-app/chess-app/Board.swift
+++ b/chess-app/chess-app/Board.swift
@@ -1,0 +1,73 @@
+//
+//  Board.swift
+//  chess-app
+//
+//  Created by Jihee hwang on 2023/10/22.
+//
+
+import Foundation
+
+// MARK: - Board
+
+final class Board {
+    private let size = 8
+    private var chessBoard = [[Piece]]()
+    
+    init() {
+        reset()
+    }
+    
+    /// 보드 초기화
+    private func reset() {
+        chessBoard = Array(
+            repeating: Array(
+                repeating: .init(
+                    type: .none,
+                    color: .none
+                ), count: size
+            ), count: size
+        )
+        
+        setupPwans()
+    }
+    
+    /// Pwan 초기화
+    private func setupPwans() {
+        let blackPwan = Piece(
+            type: .pawn,
+            color: .black
+        )
+        
+        let whitePwan = Piece(
+            type: .pawn,
+            color: .white
+        )
+        
+        chessBoard
+            .insert(Array(repeating: blackPwan,
+                          count: size
+                         ), at: Rank.two.number
+            ) 
+        
+        chessBoard
+            .insert(Array(repeating: whitePwan,
+                          count: size
+                         ), at: Rank.seven.number
+            )
+    }
+ 
+    /// 현재 보드 상태 출력
+    private func display() -> [[String]] {
+        chessBoard
+            .map { file in
+                file.map { rank in
+                    rank.color.symbol
+                }
+            }
+    }
+    
+    /// 말 이동 가능 여부 파악
+    private func move(from: Position, to: Position) -> Bool {
+        return true
+    }
+}

--- a/chess-app/chess-app/Board.swift
+++ b/chess-app/chess-app/Board.swift
@@ -55,8 +55,8 @@ final class Board {
     /// 말 이동
     func movePiece(piece: Piece, from: Position, to: Position) {
         guard piece.color == player else { return }
-        guard validateMove(piece: piece, from: from, to: to) else { return }
-        guard move(from: from, to: to) else { return }
+        guard validateMovableRange(piece: piece, from: from, to: to) else { return }
+        guard validateMove(from: from, to: to) else { return }
         
         chessBoard[to.rank][to.file] = chessBoard[from.rank][from.file]
         chessBoard[from.rank][from.file] = .init(type: .none, color: .none)
@@ -64,13 +64,13 @@ final class Board {
     }
     
     /// 이동 가능한 범위인지 확인
-    func validateMove(piece: Piece, from: Position, to: Position) -> Bool {
+    func validateMovableRange(piece: Piece, from: Position, to: Position) -> Bool {
         let distance: MovableRange = .init(rank: to.rank - from.rank, file: to.file - from.file)
         return distance == piece.movableRange
     }
     
     /// 말 이동 가능 여부 파악
-    private func move(from: Position, to: Position) -> Bool {
+    private func validateMove(from: Position, to: Position) -> Bool {
         let currentColor = getPiece(position: from).color
         let nextColor = getPiece(position: to).color
         

--- a/chess-app/chess-app/Board.swift
+++ b/chess-app/chess-app/Board.swift
@@ -46,35 +46,26 @@ final class Board {
             color: .white
         )
         
-        chessBoard
-            .insert(Array(repeating: blackPwan,
-                          count: size
-                         ), at: Rank.two.number
-            )
-        
-        chessBoard
-            .insert(Array(repeating: whitePwan,
-                          count: size
-                         ), at: Rank.seven.number
-            )
+        chessBoard[Rank.two.number] = Array(repeating: blackPwan, count: size)
+        chessBoard[Rank.seven.number] = Array(repeating: whitePwan, count: size)
     }
     
     // MARK: - Move Method
     
     /// 말 이동
-    private func movePiece(piece: Piece, from: Position, to: Position) {
+    func movePiece(piece: Piece, from: Position, to: Position) {
         guard piece.color == player else { return }
         guard validateMove(piece: piece, from: from, to: to) else { return }
         guard move(from: from, to: to) else { return }
         
-        chessBoard[to.file][to.rank] = chessBoard[from.file][from.rank]
-        chessBoard[from.file][from.rank] = .init(type: .none, color: .none)
+        chessBoard[to.rank][to.file] = chessBoard[from.rank][from.file]
+        chessBoard[from.rank][from.file] = .init(type: .none, color: .none)
         changPlayer()
     }
     
     /// 이동 가능한 범위인지 확인
-    private func validateMove(piece: Piece, from: Position, to: Position) -> Bool {
-        let distance: MovableRange = .init(file: from.file - to.file, rank: from.rank - to.rank)
+    func validateMove(piece: Piece, from: Position, to: Position) -> Bool {
+        let distance: MovableRange = .init(rank: to.rank - from.rank, file: to.file - from.file)
         return distance == piece.movableRange
     }
     
@@ -94,18 +85,18 @@ final class Board {
     // MARK: - Method
     
     /// 현재 보드 상태
-    private func display() -> [[String]] {
+    func display() -> [[String]] {
         chessBoard
-            .map { file in
-                file.map { rank in
-                    rank.color.symbol
+            .map { rank in
+                rank.map { file in
+                    file.color.symbol
                 }
             }
     }
     
     /// 특정 위치의 말
     private func getPiece(position: Position) -> Piece {
-        chessBoard[position.file][position.rank]
+        chessBoard[position.rank][position.file]
     }
     
     /// 순서 변경

--- a/chess-app/chess-app/Pieces.swift
+++ b/chess-app/chess-app/Pieces.swift
@@ -26,16 +26,16 @@ extension Piece {
         case .pawn:
             switch self.color {
             case .black:
-                return .init(file: 0, rank: 1)
+                return .init(rank: 1, file: 0)
             case .white:
-                return .init(file: 0, rank: -1)
+                return .init(rank: -1, file: 0)
             case .none:
-                return .init(file: 0, rank: 0)
+                return .init(rank: 0, file: 0)
             }
             
         // TODO: - 추후 룰 적용
         default:
-            return .init(file: 0, rank: 0)
+            return .init(rank: 0, file: 0)
         }
     }
 }
@@ -66,6 +66,7 @@ enum PieceColor {
 // MARK: - MovableRange
 
 struct MovableRange: Equatable {
-    let file: Int
-    let rank: Int
+    var rank: Int
+    var file: Int
+    
 }

--- a/chess-app/chess-app/Pieces.swift
+++ b/chess-app/chess-app/Pieces.swift
@@ -19,6 +19,27 @@ struct Piece {
     }
 }
 
+extension Piece {
+    // TODO: - 중첩 Switch문을 어떻게 해결할 것인가 ..
+    var movableRange: MovableRange {
+        switch self.type {
+        case .pawn:
+            switch self.color {
+            case .black:
+                return .init(file: 0, rank: 1)
+            case .white:
+                return .init(file: 0, rank: -1)
+            case .none:
+                return .init(file: 0, rank: 0)
+            }
+            
+        // TODO: - 추후 룰 적용
+        default:
+            return .init(file: 0, rank: 0)
+        }
+    }
+}
+
 // MARK: - PieceType
 
 enum PieceType {
@@ -40,4 +61,11 @@ enum PieceColor {
             return "."
         }
     }
+}
+
+// MARK: - MovableRange
+
+struct MovableRange: Equatable {
+    let file: Int
+    let rank: Int
 }

--- a/chess-app/chess-app/Pieces.swift
+++ b/chess-app/chess-app/Pieces.swift
@@ -1,0 +1,41 @@
+//
+//  Pieces.swift
+//  chess-app
+//
+//  Created by Jihee hwang on 2023/10/22.
+//
+
+import Foundation
+
+// MARK: - Piece
+
+struct Piece {
+    var type: PieceType
+    var color: PieceColor
+    
+    init(type: PieceType, color: PieceColor) {
+        self.type = type
+        self.color = color
+    }
+}
+
+// MARK: - PieceType
+
+enum PieceType {
+    case pawn, rook, knight, bishop, queen, king
+}
+
+// MARK: - PieceColor
+
+enum PieceColor {
+    case black, white
+    
+    var symbol: String {
+        switch self {
+        case .black:
+            return "\u{265F}"
+        case .white:
+            return "\u{2659}"
+        }
+    }
+}

--- a/chess-app/chess-app/Pieces.swift
+++ b/chess-app/chess-app/Pieces.swift
@@ -10,8 +10,8 @@ import Foundation
 // MARK: - Piece
 
 struct Piece {
-    var type: PieceType
-    var color: PieceColor
+    let type: PieceType
+    let color: PieceColor
     
     init(type: PieceType, color: PieceColor) {
         self.type = type
@@ -22,13 +22,13 @@ struct Piece {
 // MARK: - PieceType
 
 enum PieceType {
-    case pawn, rook, knight, bishop, queen, king
+    case pawn, rook, knight, bishop, queen, king, none
 }
 
 // MARK: - PieceColor
 
 enum PieceColor {
-    case black, white
+    case black, white, none
     
     var symbol: String {
         switch self {
@@ -36,6 +36,8 @@ enum PieceColor {
             return "\u{265F}"
         case .white:
             return "\u{2659}"
+        case .none:
+            return "."
         }
     }
 }

--- a/chess-app/chess-app/Position.swift
+++ b/chess-app/chess-app/Position.swift
@@ -1,0 +1,74 @@
+//
+//  Position.swift
+//  chess-app
+//
+//  Created by Jihee hwang on 2023/10/22.
+//
+
+import Foundation
+
+// MARK: - File
+
+enum File {
+    case A, B, C, D, E, F, G, H
+    
+    var number: Int {
+        switch self {
+        case .A:
+            return 0
+        case .B:
+            return 1
+        case .C:
+            return 2
+        case .D:
+            return 3
+        case .E:
+            return 4
+        case .F:
+            return 5
+        case .G:
+            return 6
+        case .H:
+            return 7
+        }
+    }
+}
+
+// MARK: - Rank
+
+enum Rank {
+    case one, two, three, four, five, six, seven, eight
+    
+    var number: Int {
+        switch self {
+        case .one:
+            return 0
+        case .two:
+            return 1
+        case .three:
+            return 2
+        case .four:
+            return 3
+        case .five:
+            return 4
+        case .six:
+            return 5
+        case .seven:
+            return 6
+        case .eight:
+            return 7
+        }
+    }
+}
+
+// MARK: - Position
+
+final class Position {
+    var file: Int
+    var rank: Int
+    
+    init(file: File, rank: Rank) {
+        self.file = file.number
+        self.rank = rank.number
+    }
+}

--- a/chess-app/chess-app/Position.swift
+++ b/chess-app/chess-app/Position.swift
@@ -7,6 +7,19 @@
 
 import Foundation
 
+// MARK: - Position
+
+final class Position {
+    var rank: Int
+    var file: Int
+    
+    init(rank: Rank, file: File) {
+        self.rank = rank.number
+        self.file = file.number
+    }
+}
+
+
 // MARK: - File
 
 enum File {
@@ -58,17 +71,5 @@ enum Rank {
         case .eight:
             return 7
         }
-    }
-}
-
-// MARK: - Position
-
-final class Position {
-    var file: Int
-    var rank: Int
-    
-    init(file: File, rank: Rank) {
-        self.file = file.number
-        self.rank = rank.number
     }
 }

--- a/chess-app/chess-app/Resources/Info.plist
+++ b/chess-app/chess-app/Resources/Info.plist
@@ -15,8 +15,6 @@
 					<string>Default Configuration</string>
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
-					<key>UISceneStoryboardFile</key>
-					<string>Main</string>
 				</dict>
 			</array>
 		</dict>

--- a/chess-app/chess-appTests/chess_appTests.swift
+++ b/chess-app/chess-appTests/chess_appTests.swift
@@ -20,4 +20,11 @@ final class chess_appTests: XCTestCase {
         
     }
     
+    func test_말의_이동_가능_여부가_정상적인지() {
+        
+    }
+    
+    func test_말을_잡았는지() {
+        
+    }
 }

--- a/chess-app/chess-appTests/chess_appTests.swift
+++ b/chess-app/chess-appTests/chess_appTests.swift
@@ -6,25 +6,85 @@
 //
 
 import XCTest
-@testable import chess_app
 
 final class chess_appTests: XCTestCase {
+    private var sut: Board!
     
     override func setUpWithError() throws {
+        sut = Board()
+        try super.setUpWithError()
     }
     
     override func tearDownWithError() throws {
+        sut = nil
+        try super.tearDownWithError()
     }
     
     func test_보드_잘_생성되었는지() {
-        
+        let mockBoard = [[".", ".", ".", ".", ".", ".", ".", "."],
+                         ["♟", "♟", "♟", "♟", "♟", "♟", "♟", "♟"],
+                         [".", ".", ".", ".", ".", ".", ".", "."],
+                         [".", ".", ".", ".", ".", ".", ".", "."],
+                         [".", ".", ".", ".", ".", ".", ".", "."],
+                         [".", ".", ".", ".", ".", ".", ".", "."],
+                         ["♙", "♙", "♙", "♙", "♙", "♙", "♙", "♙"],
+                         [".", ".", ".", ".", ".", ".", ".", "."]]
+        let testBoard = sut.display()
+        XCTAssertEqual(mockBoard, testBoard)
     }
     
-    func test_말의_이동_가능_여부가_정상적인지() {
+    func test_폰의_이동_가능_여부가_정상적인지() {
+        let from: Position = .init(rank: .seven, file: .A)
+        let to: Position = .init(rank: .five, file: .A)
         
+        let canMove = sut.validateMove(piece: .init(type: .pawn, color: .white),
+                                      from: from,
+                                      to: to)
+        
+        XCTAssertEqual(canMove, false)
+    }
+    
+    func test_폰의_이동_가능_여부가_정상적인지2() {
+        let from: Position = .init(rank: .one, file: .A)
+        let to: Position = .init(rank: .two, file: .A)
+        
+        let canMove = sut.validateMove(piece: .init(type: .pawn, color: .black),
+                                      from: from,
+                                      to: to)
+        
+        XCTAssertEqual(canMove, true)
     }
     
     func test_말을_잡았는지() {
+        let mockBoard = [[".", ".", ".", ".", ".", ".", ".", "."],
+                         [".", "♟", "♟", "♟", "♟", "♟", "♟", "♟"],
+                         [".", ".", ".", ".", ".", ".", ".", "."],
+                         ["♙", ".", ".", ".", ".", ".", ".", "."],
+                         [".", ".", ".", ".", ".", ".", ".", "."],
+                         [".", ".", ".", ".", ".", ".", ".", "."],
+                         [".", "♙", "♙", "♙", "♙", "♙", "♙", "♙"],
+                         [".", ".", ".", ".", ".", ".", ".", "."]]
+        sut.movePiece(piece: .init(type: .pawn, color: .white),
+                      from: .init(rank: .seven, file: .A),
+                      to: .init(rank: .six, file: .A))
         
+        sut.movePiece(piece: .init(type: .pawn, color: .black),
+                      from: .init(rank: .two, file: .A),
+                      to: .init(rank: .three, file: .A))
+        
+        sut.movePiece(piece: .init(type: .pawn, color: .white),
+                      from: .init(rank: .six, file: .A),
+                      to: .init(rank: .five, file: .A))
+        
+        sut.movePiece(piece: .init(type: .pawn, color: .black),
+                      from: .init(rank: .three, file: .A),
+                      to: .init(rank: .four, file: .A))
+        
+        sut.movePiece(piece: .init(type: .pawn, color: .white),
+                      from: .init(rank: .five, file: .A),
+                      to: .init(rank: .four, file: .A))
+        
+        let testBoard = sut.display()
+        XCTAssertEqual(mockBoard, testBoard)
     }
 }

--- a/chess-app/chess-appTests/chess_appTests.swift
+++ b/chess-app/chess-appTests/chess_appTests.swift
@@ -9,28 +9,15 @@ import XCTest
 @testable import chess_app
 
 final class chess_appTests: XCTestCase {
-
+    
     override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-
+    
     override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
     }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    
+    func test_보드_잘_생성되었는지() {
+        
     }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
+    
 }

--- a/chess-app/chess-appTests/chess_appTests.swift
+++ b/chess-app/chess-appTests/chess_appTests.swift
@@ -37,9 +37,9 @@ final class chess_appTests: XCTestCase {
         let from: Position = .init(rank: .seven, file: .A)
         let to: Position = .init(rank: .five, file: .A)
         
-        let canMove = sut.validateMove(piece: .init(type: .pawn, color: .white),
-                                      from: from,
-                                      to: to)
+        let canMove = sut.validateMovableRange(piece: .init(type: .pawn, color: .white),
+                                               from: from,
+                                               to: to)
         
         XCTAssertEqual(canMove, false)
     }
@@ -48,9 +48,9 @@ final class chess_appTests: XCTestCase {
         let from: Position = .init(rank: .one, file: .A)
         let to: Position = .init(rank: .two, file: .A)
         
-        let canMove = sut.validateMove(piece: .init(type: .pawn, color: .black),
-                                      from: from,
-                                      to: to)
+        let canMove = sut.validateMovableRange(piece: .init(type: .pawn, color: .black),
+                                               from: from,
+                                               to: to)
         
         XCTAssertEqual(canMove, true)
     }


### PR DESCRIPTION
안녕하세요 JK! 하루 마무리 잘 하고 계신가요? ㅎ_ㅎ
조금 늦은 1주차 PR입니다 ! ☺️

조언해주신대로 처음으로 시뮬레이터나 프린트문을 사용하지않고, 
테스트코드로만 로직이 잘 동작하는지 확인했습니다 !
너무 신선한 경험이었고, 재밌었습니다 ㅎㅎ

# 요구사항
- [x] 시뮬레이터를 실행하지 않고 기능을 구현하고 검증하는 과정에 집중
- [x] 입/출력 로직 없이, 핵심 로직만 구현 후 단위테스트로 확인
- [x] 게임 시작시 2-rank는 흑백 폰이, 7-rank는 백색 폰이 위치
- [x] 체스말을 이동하는 명령은 백색부터 시작해서, 흑과 백이 번갈아서 처리
- [x] 8x8 크기 체스판에 체스말(Piece) 존재 여부를 관리
- [x] display() 함수를 통해, 현재 보드 위의 체스말을 문자열 배열로 리턴
- [x] 말의 이동 여부를 알 수 있는 메서드를 구현
  - [x] 같은 색상의 말이 to 위치에 있으면 옮길 수 없음
  - [x] 다른 색상의 말이 to 위치에 있으면, 해당 말을 잡음
  - [x] 말을 옮길 수 있으면 True/ 없으면 False를 리턴

# 고민과 해결
#### ✔️ 고민 - 말의 이동 가능 범위(Rules)를 어디서 관리할 것인가 ?
각 말마다 이동할 수 있는 규칙이 다른데 그걸 `누가` `어떻게` 관리해야하나 고민이 들었습니다.
아래 방법으로 구현했으나, 최선은 아니라는 생각이 들어 더 나은 방법을 고민하고 있습니다.

#### ✔️ 해결
우선적으로 모든 말의 이동 범위는, 말을 추상화 해놓은 객체인 Piece가 갖고 있어야 한다는 생각이 들었습니다.
같은 말이라 하더라도 색에 따라 이동 범위가 달라지게 됩니다.
때문에,  말의 타입과 컬러를 모두 알고 있는 Piece가 해당 역할을 수행하는게 맞다고 판단해
Piece 객체 내부에 `movableRange`를 구현했습니다.
++ `movableRange`를 구현하며 생긴 중첩 Switch문의 개선 방법도 고민하고 있습니다!

감사합니다 !